### PR TITLE
More consistant global usage for config

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -16,6 +16,8 @@
 
 #define DEFAULT_LIST_SIZE 10
 
+struct config_list *config = NULL;
+
 struct parser_context {
         const char *buffer;
         size_t buffer_size;
@@ -696,8 +698,7 @@ void destroy_config_value(struct config_value *value)
  * Takes a string buffer and uses it to return the key value pairs
  * of the config
  */
-struct config_list *initialize_config_string(const char *string,
-                                             size_t config_size)
+struct config_list *read_config_string(const char *string, size_t config_size)
 {
         struct parser_context *context
                 = initialize_parser_context(string, config_size);
@@ -721,12 +722,12 @@ struct config_list *initialize_config_string(const char *string,
  * into a buffer and uses it to return the key value pairs of the config
  * file
  */
-struct config_list *initialize_config_path(const char *path)
+int initialize_config_path(const char *path)
 {
         FILE *file = open_config_file(path);
 
         if (file == NULL) {
-                return NULL;
+                return -1;
         }
 
         ssize_t ftell_result = get_file_size(file);
@@ -742,10 +743,9 @@ struct config_list *initialize_config_path(const char *path)
                 goto close_file_and_error;
         }
 
-        struct config_list *list
-                = initialize_config_string(file_buffer, file_size);
+        config = read_config_string(file_buffer, file_size);
 
-        if (list == NULL) {
+        if (config == NULL) {
                 free(file_buffer);
 
                 goto close_file_and_error;
@@ -754,10 +754,10 @@ struct config_list *initialize_config_path(const char *path)
         free(file_buffer);
         fclose(file);
 
-        return list;
+        return 0;
 
 close_file_and_error:
         fclose(file);
 
-        return NULL;
+        return -1;
 }

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -47,6 +47,5 @@ struct config_value *config_list_find(struct config_list *list,
 void destroy_config_list(struct config_list *list);
 void destroy_config_value(struct config_value *value);
 
-struct config_list *initialize_config_string(const char *config,
-                                             size_t config_size);
-struct config_list *initialize_config_path(const char *path);
+struct config_list *read_config_string(const char *config, size_t config_size);
+int initialize_config_path(const char *path);

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -39,7 +39,7 @@ static void test_config_simple_config(void **state)
         const char *config_string = "name = \"John\"\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
         struct config_value *value = config_list_find(list, expected_key);
 
         assert_non_null(list);
@@ -58,7 +58,7 @@ static void test_config_number_variable(void **state)
         const char *config_string = "$test = 100\nage = $test\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
         struct config_value *value = config_list_find(list, expected_key);
 
         assert_non_null(list);
@@ -77,7 +77,7 @@ static void test_config_string_variable(void **state)
         const char *config_string = "$test = \"testing\"\nname = $test\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
         struct config_value *value = config_list_find(list, expected_key);
 
         assert_non_null(list);
@@ -95,7 +95,7 @@ static void test_config_comment(void **state)
         const char *config_string = "// An example comment\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_non_null(list);
         assert_int_equal(expected_result, list->length);
@@ -111,7 +111,7 @@ static void test_config_double_definition(void **state)
                 = "$first = \"first\"\n$second = $first\ntest = $second\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
         struct config_value *value = config_list_find(list, expected_key);
 
         assert_non_null(list);
@@ -128,7 +128,7 @@ static void test_config_unset_variable(void **state)
         const char *config_string = "test = $undefined\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }
@@ -138,7 +138,7 @@ static void test_config_invalid_number(void **state)
         const char *config_string = "$number = not a number\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }
@@ -148,7 +148,7 @@ static void test_config_invalid_single_quotes(void **state)
         const char *config_string = "$string = 'invalid'\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }
@@ -158,7 +158,7 @@ static void test_config_invalid_variable(void **state)
         const char *config_string = "$invalid =\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }
@@ -168,7 +168,7 @@ static void test_config_invalid_item(void **state)
         const char *config_string = "invalid = \n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }
@@ -178,7 +178,7 @@ static void test_config_invalid_double(void **state)
         const char *config_string = "$number = 2.3\n";
         size_t config_length = strlen(config_string);
         struct config_list *list
-                = initialize_config_string(config_string, config_length);
+                = read_config_string(config_string, config_length);
 
         assert_null(list);
 }


### PR DESCRIPTION
Store extern and declaration of global in config c,h files just like how
we are handling logging

Signed-off-by: Chris Frank <chris@cfrank.org>