### PR TITLE
Feature/ansi signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ endif()
 
 option(ENABLE_TESTING "Enable automated testing" OFF)
 
+option(USE_POSIX "Enable POSIX 2001 extensions" ON)
+
+if(USE_POSIX)
+    add_compile_definitions(USE_POSIX=1)
+endif()
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_SRCS_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -1,9 +1,6 @@
-
 #ifdef USE_POSIX
-
 // Required for handling signals
 #define _POSIX_C_SOURCE 200809L
-
 #endif
 
 #include <getopt.h>


### PR DESCRIPTION
instead of requiring everyone to be on a posix machine that supports the
2001 standard allow compiling with purly ansi support (might not work
with xcb libs)

This allows for the statement that all natwm specific code is ansi c99
compliant

If you don't compile with POSIX support and send a SIGHUP signal the program will exit with a hangup error. If you DO compile with POSIX support you will be able to reload the configuration file.

By default POSIX support should be enabled