### PR TITLE
Improve config_path resolution

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -583,6 +583,12 @@ static FILE *open_config_file(const char *path)
 
         char *config_path = get_config_path();
 
+        if (config_path == NULL) {
+                LOG_ERROR(natwm_logger, "Failed to find HOME directory");
+
+                return NULL;
+        }
+
         string_append(&config_path, NATWM_CONFIG_FILE);
 
         // Check if the file exists

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -518,6 +518,43 @@ static int parse_context_config_item(struct parser_context *context,
 }
 
 /**
+ * Try to find the configuration file
+ *
+ * Uses a couple common locations and falls back to searching the .confg
+ * directory in the users HOME directory
+ */
+static char *get_config_path(void)
+{
+        const char *base_directory = NULL;
+        char *config_path = NULL;
+
+        if ((base_directory = getenv("XDG_CONFIG_HOME")) != NULL) {
+                config_path = alloc_string(base_directory);
+
+                return config_path;
+        }
+
+        if ((base_directory = getenv("HOME")) != NULL) {
+                config_path = alloc_string(base_directory);
+                string_append(&config_path, "/.config/");
+
+                return config_path;
+        }
+
+        // If we still haven't found anything use passwd
+        struct passwd *db = getpwuid(getuid());
+
+        if (db == NULL) {
+                return NULL;
+        }
+
+        config_path = alloc_string(db->pw_dir);
+        string_append(&config_path, "/.config/");
+
+        return config_path;
+}
+
+/**
  * Open a configuration file
  *
  * This can either be supplied by the caller (through the first
@@ -544,18 +581,8 @@ static FILE *open_config_file(const char *path)
                 return file;
         }
 
-        // Otherwise use the default location
-        struct passwd *db = getpwuid(getuid());
+        char *config_path = get_config_path();
 
-        if (db == NULL) {
-                LOG_ERROR(natwm_logger, "Failed to find HOME directory");
-
-                return NULL;
-        }
-
-        char *config_path = alloc_string(db->pw_dir);
-
-        string_append(&config_path, "/.config/");
         string_append(&config_path, NATWM_CONFIG_FILE);
 
         // Check if the file exists

--- a/src/natwm/CMakeLists.txt
+++ b/src/natwm/CMakeLists.txt
@@ -13,9 +13,5 @@ target_link_libraries(natwm
     PRIVATE
         common
         core
-)
-
-target_link_libraries(natwm
-    PRIVATE
         xcb
 )

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -86,7 +86,6 @@ static void signal_handler(int signum)
                 return;
         }
 #endif
-
         program_state = STOPPED;
 }
 
@@ -140,7 +139,6 @@ static int start_natwm(xcb_connection_t *connection, const char *config_path)
                 LOG_INFO(natwm_logger, val->data.string);
 
                 sleep(1);
-
 #ifdef USE_POSIX
                 if (program_state & RELOAD) {
                         LOG_INFO(natwm_logger, "Reloading natwm...");

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -252,8 +252,6 @@ int main(int argc, char **argv)
                 goto free_and_error;
         }
 
-        printf("Right? %zu\n", config->size);
-
         // Catch and handle signals
         if (install_signal_handlers() < 0) {
                 LOG_ERROR(


### PR DESCRIPTION
Previously we used passwd to determine the users home directory then
forced then appened /.config/ to that path. This was very unflexable and
didn't allow the user any chance to change it. with these changes we now
try to find a user specified config dir before falling back to the
passwd solution.

As of now we are checking the following:

XDG_CONFIG_HOME
HOME
passwd

Signed-off-by: Chris Frank <chris@cfrank.org>