### PR TITLE
Add support for _NET_SUPPORTING_WM_CHECK

### DIFF
--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -298,7 +298,6 @@ int main(int argc, char **argv)
         LOG_INFO(natwm_logger, "Successfully connected to X server");
 
         // Find the default screen
-
         xcb_screen_t *default_screen
                 = find_default_screen(state->xcb, screen_num);
 


### PR DESCRIPTION
Creates simple window and attach it to the net supporting wm check
property. Also set the window manager name on the window. This allows
for clients to tell that a supporting window manager is running

Signed-off-by: Chris Frank <chris@cfrank.org>