### PR TITLE
Chore/cmake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,24 +21,17 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_definitions(IS_DEBUG_BUILD=0)
 else()
-    message(STATUS "No CMAKE_BUILD_TYPE specified - Defaulting to \"Debug\"")
+    message(STATUS "Defauling CMAKE_BUILD_TYPE to \"Debug\"")
     set(CMAKE_BUILD_TYPE "Debug")
     add_compile_definitions(IS_DEBUG_BUILD=1)
 endif()
 
 option(ENABLE_TESTING "Enable automated testing" OFF)
 
-option(USE_POSIX "Enable POSIX 2001 extensions" ON)
-
-if(USE_POSIX)
-    add_compile_definitions(USE_POSIX=1)
-endif()
-
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_SRCS_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
 
 # Clang Format target
-
 set(CLANG_FORMAT_POSTFIX "-7.0")
 find_program(CLANG_FORMAT
     NAMES clang-format${CLANG_FORMAT_POSTFIX}
@@ -55,31 +48,6 @@ else()
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-# Compilation flags
-
-string(APPEND CMAKE_C_FLAGS_DEBUG " -g3"
-    " -O")
-
-string(APPEND CMAKE_C_FLAGS_RELEASE " -O2"
-    " -march=native"
-    " -mtune=native"
-    " -fsanitize=address"
-    " -ftree-vectorize")
-
-string(APPEND CMAKE_C_FLAGS " -Wall"
-    " -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2"
-    " -Wextra -Wcast-align -Wcast-qual -Wpointer-arith"
-    " -Wunreachable-code -Wfloat-equal"
-    " -Wformat=2 -Wredundant-decls -Wundef"
-    " -Wdisabled-optimization -Wshadow -Wmissing-braces"
-    " -Wstrict-aliasing=2 -Wstrict-overflow=5 -Wconversion"
-    " -Wno-unused-parameter"
-    " -pedantic")
-
-# Linker flags
-
-string(APPEND CMAKE_LINK_FLAGS_RELEASE " -fsanitize=address")
 
 if(ENABLE_TESTING)
     include(CTest)

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ readonly BUILD="dev"
 readonly SYSTEM="system"
 
 function show_help() {
-    echo "Usage: ./run <$BUILD|$SYSTEM> <wxh>"
+    echo "Usage: ./run <$BUILD|$SYSTEM> <wxh> <wait?>"
 }
 
 readonly XEPHYR="Xephyr"
@@ -20,7 +20,7 @@ readonly SYSTEM_BIN_DIR="/usr/bin"
 readonly BUILD_BIN="$BUILD_BIN_DIR"/"$APP_NAME"
 readonly SYSTEM_BIN="$SYSTEM_BIN_DIR"/"$APP_NAME"
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
     echo Invalid arguments count
 
     show_help
@@ -38,11 +38,17 @@ fi
 
 # Stupidly simple validation that this string at least contains an x
 if [[ "$2" != *"x"* ]]; then
-    echo Invalid argument: "$2" - Expected to be in the form \"800x600\"
+    echo Invalid argument: \""$2"\" - Expected to be in the form \"800x600\"
 
     show_help
 
     exit
+fi
+
+SHOULD_WAIT=false
+
+if [ $# -eq 3 ] && [ "$3" == "wait" ]; then
+    SHOULD_WAIT=true
 fi
 
 readonly EXEC_TYPE=$1
@@ -61,7 +67,12 @@ else
 fi
 
 $XEPHYR :14 -ac -nolisten tcp -screen $SCREEN_RES &
-sleep 5
+
+if [ $SHOULD_WAIT == true ]; then
+    sleep 5
+else
+    sleep 1
+fi
 
 export DISPLAY=:14
 $($BIN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_options(
     -Wstrict-overflow
     -Wconversion
     -fno-strict-aliasing
-    -D_POSIX_SOURCE=200112L
+    -D_POSIX_C_SOURCE
     "$<$<CONFIG:DEBUG>:-g>"
     "$<$<CONFIG:DEBUG>:-Werror>"
     "$<$<CONFIG:DEBUG>:-Wshadow>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_options(
     -Wstrict-overflow
     -Wconversion
     -fno-strict-aliasing
-    -D_POSIX_C_SOURCE
+    -D_POSIX_C_SOURCE=200809L
     "$<$<CONFIG:DEBUG>:-g>"
     "$<$<CONFIG:DEBUG>:-Werror>"
     "$<$<CONFIG:DEBUG>:-Wshadow>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,24 @@
 include_directories(.)
 
+add_compile_options(
+    -march=native
+    -Wall
+    -pedantic
+    -Wextra
+    -Wstrict-overflow
+    -Wconversion
+    -fno-strict-aliasing
+    -D_POSIX_SOURCE=200112L
+    "$<$<CONFIG:DEBUG>:-g>"
+    "$<$<CONFIG:DEBUG>:-Werror>"
+    "$<$<CONFIG:DEBUG>:-Wshadow>"
+    "$<$<CONFIG:RELEASE>:-O3 -Os>"
+)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
 add_subdirectory(common)
 
 add_subdirectory(core)

--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -16,4 +16,6 @@
 #define ATTR_INLINE inline
 #endif
 
+#define UNUSED_FUNCTION_PARAM(param) (void)(param)
+
 #define NATWM_CONFIG_FILE "natwm/config"

--- a/src/common/hash.c
+++ b/src/common/hash.c
@@ -73,4 +73,3 @@ ATTR_CONST uint32_t hash_murmur3_32(const void *data, size_t len, uint32_t seed)
 
         return hash;
 }
-

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -8,6 +8,8 @@
 #include "ewmh.h"
 
 // Create a simple window for the _NET_SUPPORTING_WM_CHECK property
+//
+// Return the ID of the created window
 static xcb_window_t create_supporting_window(const struct natwm_state *state)
 {
         xcb_window_t win = xcb_generate_id(state->xcb);
@@ -54,12 +56,13 @@ xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection)
 void ewmh_init(const struct natwm_state *state)
 {
         // Base info
-        uint32_t pid = (uint32_t)getpid(); // set_wm_pid expects uint32_t
+        pid_t pid = getpid();
+        size_t wm_name_len = strlen(NATWM_VERSION_STRING);
 
-        xcb_ewmh_set_wm_pid(state->ewmh, state->screen->root, pid);
+        xcb_ewmh_set_wm_pid(state->ewmh, state->screen->root, (uint32_t)pid);
         xcb_ewmh_set_wm_name(state->ewmh,
                              state->screen->root,
-                             strlen(NATWM_VERSION_STRING),
+                             (uint32_t)wm_name_len,
                              NATWM_VERSION_STRING);
 
         // A list of supported atoms
@@ -108,9 +111,10 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_WM_STATE_DEMANDS_ATTENTION,
         };
 
-        uint32_t len = (uint32_t)(sizeof(net_atoms) / sizeof(xcb_atom_t));
+        size_t len = (sizeof(net_atoms) / sizeof(xcb_atom_t));
 
-        xcb_ewmh_set_supported(state->ewmh, state->screen_num, len, net_atoms);
+        xcb_ewmh_set_supported(
+                state->ewmh, state->screen_num, (uint32_t)len, net_atoms);
 
         xcb_window_t supporting_win = create_supporting_window(state);
 
@@ -120,7 +124,7 @@ void ewmh_init(const struct natwm_state *state)
         // Set the WM name on the supporting win
         xcb_ewmh_set_wm_name(state->ewmh,
                              supporting_win,
-                             strlen(NATWM_VERSION_STRING),
+                             (uint32_t)wm_name_len,
                              NATWM_VERSION_STRING);
 }
 

--- a/src/core/map.c
+++ b/src/core/map.c
@@ -57,11 +57,10 @@ static int map_lock(struct map *map)
                 return 0;
         }
 
-#ifdef USE_POSIX
         if (pthread_mutex_lock(&map->mutex) != 0) {
                 return -1;
         }
-#endif
+
         return 0;
 }
 
@@ -74,11 +73,10 @@ static int map_unlock(struct map *map)
                 return 0;
         }
 
-#ifdef USE_POSIX
         if (pthread_mutex_unlock(&map->mutex) != 0) {
                 return -1;
         }
-#endif
+
         return 0;
 }
 
@@ -372,11 +370,10 @@ struct map *map_init(void)
                 return NULL;
         }
 
-#ifdef USE_POSIX
         if (pthread_mutex_init(&map->mutex, NULL) != 0) {
                 return NULL;
         }
-#endif
+
         map->hash_function = default_key_hash;
         map->free_function = NULL;
         map->setting_flags = MAP_FLAG_IGNORE_THRESHOLDS_EMPTY;

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
-#ifdef USE_POSIX
 #include <pthread.h>
-#endif
+#include <stdint.h>
 
 #include <common/error.h>
 
@@ -77,9 +74,7 @@ struct map {
         uint32_t length; // Length of the map (power of 2)
         uint32_t bucket_count;
         struct map_entry **entries;
-#ifdef USE_POSIX
         pthread_mutex_t mutex;
-#endif
         map_hash_function_t hash_function;
         map_entry_free_function_t free_function;
         enum map_settings setting_flags;

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -11,7 +11,7 @@ xcb_screen_t *find_default_screen(xcb_connection_t *connection, int screen_num)
         xcb_screen_iterator_t itr = xcb_setup_roots_iterator(setup);
 
         for (int i = screen_num; itr.rem; --i, xcb_screen_next(&itr)) {
-                if (i == screen_num) {
+                if (i == 0) {
                         return itr.data;
                 }
         }

--- a/src/natwm/CMakeLists.txt
+++ b/src/natwm/CMakeLists.txt
@@ -5,8 +5,6 @@ add_executable(natwm
 set_target_properties(natwm
     PROPERTIES
     VERSION ${PROJECT_VERSION}
-    C_STANDARD 99
-    C_EXTENSIONS OFF
 )
 
 target_link_libraries(natwm

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -2,11 +2,6 @@
 // Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
-#ifdef USE_POSIX
-// Required for handling POSIX signals
-#define _POSIX_C_SOURCE 200809L
-#endif
-
 #include <getopt.h>
 #include <signal.h>
 #include <stdio.h>
@@ -30,9 +25,7 @@ struct argument_options {
 enum status {
         STOPPED = 1U << 0U,
         RUNNING = 1U << 1U,
-#ifdef USE_POSIX
         RELOAD = 1U << 2U,
-#endif
 };
 
 static enum status program_status = STOPPED;
@@ -85,20 +78,18 @@ static xcb_connection_t *make_connection(const char *screen, int *screen_num)
 
 static void signal_handler(int signum)
 {
-#ifdef USE_POSIX
         if (signum == SIGHUP) {
                 // Perform a reload
                 program_status |= RELOAD;
 
                 return;
         }
-#endif
+
         program_status = STOPPED;
 }
 
 static int install_signal_handlers(void)
 {
-#ifdef USE_POSIX
         struct sigaction action;
 
         action.sa_handler = &signal_handler;
@@ -119,23 +110,6 @@ static int install_signal_handlers(void)
         }
 
         return 0;
-#else
-        // Install interupt handler using ansi signals
-
-        if (signal(SIGINT, signal_handler) == SIG_ERR) {
-                LOG_ERROR(natwm_logger, "Failed to handle SIGINT");
-
-                return -1;
-        }
-
-        if (signal(SIGTERM, signal_handler) == SIG_ERR) {
-                LOG_ERROR(natwm_logger, "Failed to handle SIGTERM");
-
-                return -1;
-        }
-
-        return 0;
-#endif
 }
 
 static bool is_other_wm_present(struct natwm_state *state)
@@ -161,7 +135,7 @@ static int start_natwm(struct natwm_state *state, const char *config_path)
 {
         while (program_status & RUNNING) {
                 sleep(1);
-#ifdef USE_POSIX
+
                 if (program_status & RELOAD) {
                         LOG_INFO(natwm_logger, "Reloading natwm...");
 
@@ -183,7 +157,6 @@ static int start_natwm(struct natwm_state *state, const char *config_path)
 
                         program_status &= (uint8_t)~RELOAD;
                 }
-#endif
         }
 
         // Event loop stopped disconnect from x

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -160,6 +160,7 @@ static bool is_other_wm_present(struct natwm_state *state)
 static int start_natwm(struct natwm_state *state, const char *config_path)
 {
         while (program_status & RUNNING) {
+                sleep(1);
 #ifdef USE_POSIX
                 if (program_status & RELOAD) {
                         LOG_INFO(natwm_logger, "Reloading natwm...");

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -160,11 +160,6 @@ static bool is_other_wm_present(struct natwm_state *state)
 static int start_natwm(struct natwm_state *state, const char *config_path)
 {
         while (program_status & RUNNING) {
-                struct config_value *val = config_find(state->config, "author");
-
-                LOG_INFO(natwm_logger, val->data.string);
-
-                sleep(1);
 #ifdef USE_POSIX
                 if (program_status & RELOAD) {
                         LOG_INFO(natwm_logger, "Reloading natwm...");
@@ -185,7 +180,7 @@ static int start_natwm(struct natwm_state *state, const char *config_path)
 
                         state->config = new_config;
 
-                        program_status &= (unsigned int)~RELOAD;
+                        program_status &= (uint8_t)~RELOAD;
                 }
 #endif
         }
@@ -283,8 +278,6 @@ int main(int argc, char **argv)
 
                 exit(EXIT_FAILURE);
         }
-
-        LOG_INFO(natwm_logger, "Initializing with screen: %d", screen_num);
 
         state->screen_num = screen_num;
 

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -10,6 +10,7 @@
 
 #include <cmocka.h>
 
+#include <common/constants.h>
 #include <common/logger.h>
 #include <core/config.h>
 
@@ -18,6 +19,8 @@
  */
 static int global_test_setup(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         initialize_logger(false);
 
         // Logs will now be noops
@@ -28,6 +31,8 @@ static int global_test_setup(void **state)
 
 static int global_test_teardown(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         destroy_logger(natwm_logger);
 
         return EXIT_SUCCESS;
@@ -35,6 +40,8 @@ static int global_test_teardown(void **state)
 
 static void test_config_simple_config(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_key = "name";
         const char *expected_value = "John";
         const char *config_string = "name = \"John\"\n";
@@ -54,6 +61,8 @@ static void test_config_simple_config(void **state)
 
 static void test_config_number_variable(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_key = "age";
         intmax_t expected_value = 100;
         const char *config_string = "$test = 100\nage = $test\n";
@@ -73,6 +82,8 @@ static void test_config_number_variable(void **state)
 
 static void test_config_string_variable(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_key = "name";
         const char *expected_value = "testing";
         const char *config_string = "$test = \"testing\"\nname = $test\n";
@@ -92,6 +103,8 @@ static void test_config_string_variable(void **state)
 
 static void test_config_comment(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_result = 0;
         const char *config_string = "// An example comment\n";
         size_t config_length = strlen(config_string);
@@ -106,6 +119,8 @@ static void test_config_comment(void **state)
 
 static void test_config_double_definition(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_key = "test";
         const char *expected_value = "first";
         const char *config_string
@@ -126,6 +141,8 @@ static void test_config_double_definition(void **state)
 
 static void test_config_unset_variable(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "test = $undefined\n";
         size_t config_length = strlen(config_string);
         struct map *config_map
@@ -136,6 +153,8 @@ static void test_config_unset_variable(void **state)
 
 static void test_config_invalid_number(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "$number = not a number\n";
         size_t config_length = strlen(config_string);
         struct map *config_map
@@ -146,6 +165,8 @@ static void test_config_invalid_number(void **state)
 
 static void test_config_invalid_single_quotes(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "$string = 'invalid'\n";
         size_t config_length = strlen(config_string);
         struct map *config_map
@@ -156,6 +177,8 @@ static void test_config_invalid_single_quotes(void **state)
 
 static void test_config_invalid_variable(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "$invalid =\n";
         size_t config_length = strlen(config_string);
         struct map *config_map
@@ -166,6 +189,8 @@ static void test_config_invalid_variable(void **state)
 
 static void test_config_invalid_item(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "invalid = \n";
         size_t config_length = strlen(config_string);
         struct map *config_map
@@ -176,6 +201,8 @@ static void test_config_invalid_item(void **state)
 
 static void test_config_invalid_double(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *config_string = "$number = 2.3\n";
         size_t config_length = strlen(config_string);
         struct map *config_map

--- a/src/test/test_list.c
+++ b/src/test/test_list.c
@@ -369,4 +369,3 @@ int main(void)
 
         return cmocka_run_group_tests(tests, NULL, NULL);
 }
-

--- a/src/test/test_list.c
+++ b/src/test/test_list.c
@@ -10,6 +10,7 @@
 
 #include <cmocka.h>
 
+#include <common/constants.h>
 #include <core/list.h>
 
 static int test_setup(void **state)
@@ -34,6 +35,8 @@ static int test_teardown(void **state)
 
 static void test_node_creation_succeeds(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         int expected_data = 10;
         struct node *node = create_node(&expected_data);
 

--- a/src/test/test_map.c
+++ b/src/test/test_map.c
@@ -9,6 +9,7 @@
 
 #include <cmocka.h>
 
+#include <common/constants.h>
 #include <common/error.h>
 #include <core/map.h>
 
@@ -355,6 +356,8 @@ static void test_map_get_and_delete(void **state)
 
 static void test_map_destroy_null(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         map_destroy(NULL);
 }
 

--- a/src/test/test_string_util.c
+++ b/src/test/test_string_util.c
@@ -11,11 +11,14 @@
 
 #include <cmocka.h>
 
+#include <common/constants.h>
 #include <common/error.h>
 #include <common/string.h>
 
 static void test_string_init(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "Test String";
         char *result = string_init(expected_string);
 
@@ -27,6 +30,8 @@ static void test_string_init(void **state)
 
 static void test_string_append(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "TestString";
         char *first_string = string_init("Test");
         char *second_string = string_init("String");
@@ -43,6 +48,8 @@ static void test_string_append(void **state)
 
 static void test_string_append_empty_append(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "Test";
         char *first_string = string_init(expected_string);
 
@@ -55,6 +62,8 @@ static void test_string_append_empty_append(void **state)
 
 static void test_string_append_empty_destination(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "String";
         char *first_string = string_init("");
         char *second_string = string_init(expected_string);
@@ -69,6 +78,8 @@ static void test_string_append_empty_destination(void **state)
 
 static void test_string_append_char_succeeds(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "Test.";
         char *first_string = string_init("Test");
 
@@ -81,6 +92,8 @@ static void test_string_append_char_succeeds(void **state)
 
 static void test_string_append_char_empty_append(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = "Test";
         char *first_string = string_init(expected_string);
 
@@ -93,6 +106,8 @@ static void test_string_append_char_empty_append(void **state)
 
 static void test_string_append_char_empty_destination(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *expected_string = ".";
         char *first_string = string_init("");
 
@@ -105,6 +120,8 @@ static void test_string_append_char_empty_destination(void **state)
 
 static void test_string_find_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_index = 5;
         const char *string = "Hello!";
         size_t index = 0;
@@ -116,6 +133,8 @@ static void test_string_find_char(void **state)
 
 static void test_string_find_char_not_found(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *string = "Not Found";
 
         assert_int_equal(NOT_FOUND_ERROR, string_find_char(string, '!', NULL));
@@ -123,6 +142,8 @@ static void test_string_find_char_not_found(void **state)
 
 static void test_string_find_char_empty_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *string = "";
 
         assert_int_equal(NOT_FOUND_ERROR, string_find_char(string, '!', NULL));
@@ -130,6 +151,8 @@ static void test_string_find_char_empty_string(void **state)
 
 static void test_string_find_char_null_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *string = NULL;
 
         assert_int_equal(INVALID_INPUT_ERROR,
@@ -138,6 +161,8 @@ static void test_string_find_char_null_string(void **state)
 
 static void test_string_find_first_nonspace(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_index = 3;
         size_t index = 0;
         const char *string = "   Hello world!";
@@ -148,6 +173,8 @@ static void test_string_find_first_nonspace(void **state)
 
 static void test_string_find_first_nonspace_not_found(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *string = "   ";
         size_t index = 0;
 
@@ -157,6 +184,8 @@ static void test_string_find_first_nonspace_not_found(void **state)
 
 static void test_string_find_first_nonspace_single_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_index = 0;
         size_t index = 0;
         const char *string = "H";
@@ -167,6 +196,8 @@ static void test_string_find_first_nonspace_single_char(void **state)
 
 static void test_string_find_first_nonspace_null_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t index = 0;
         assert_int_equal(INVALID_INPUT_ERROR,
                          string_find_first_nonspace(NULL, &index));
@@ -174,6 +205,8 @@ static void test_string_find_first_nonspace_null_string(void **state)
 
 static void test_string_find_last_nonspace(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_index = 11;
         size_t index = 0;
         const char *string = "Hello World!    ";
@@ -184,6 +217,8 @@ static void test_string_find_last_nonspace(void **state)
 
 static void test_string_find_last_nonspace_not_found(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *string = "    ";
         size_t index = 0;
 
@@ -193,6 +228,8 @@ static void test_string_find_last_nonspace_not_found(void **state)
 
 static void test_string_find_last_nonspace_single_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         size_t expected_index = 0;
         size_t index = 0;
         const char *str = "H";
@@ -203,12 +240,16 @@ static void test_string_find_last_nonspace_single_char(void **state)
 
 static void test_string_find_last_nonspace_null_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         assert_int_equal(INVALID_INPUT_ERROR,
                          string_find_last_nonspace(NULL, NULL));
 }
 
 static void test_string_get_delimiter(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Hello world! My name is computer";
         const char *expected_string = "Hello world!";
         char *destination = NULL;
@@ -227,6 +268,8 @@ static void test_string_get_delimiter(void **state)
 
 static void test_string_get_delimiter_not_found(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Hello world!";
         char *destination = NULL;
 
@@ -237,6 +280,8 @@ static void test_string_get_delimiter_not_found(void **state)
 
 static void test_string_get_delimiter_first_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Hello world!";
         const char *expected_string = "H";
         char *destination = NULL;
@@ -256,6 +301,8 @@ static void test_string_get_delimiter_first_char(void **state)
 
 static void test_string_get_delimiter_empty_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "";
         char *destination = NULL;
 
@@ -266,6 +313,8 @@ static void test_string_get_delimiter_empty_string(void **state)
 
 static void test_string_to_number(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "1520";
         intmax_t expected_number = 1520;
         intmax_t destination = 0;
@@ -276,6 +325,8 @@ static void test_string_to_number(void **state)
 
 static void test_string_to_number_negative(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "-3455";
         intmax_t expected_number = -3455;
         intmax_t destination = 0;
@@ -286,6 +337,8 @@ static void test_string_to_number_negative(void **state)
 
 static void test_string_to_number_invalid_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "123abc";
         intmax_t destination = 0;
 
@@ -296,6 +349,8 @@ static void test_string_to_number_invalid_char(void **state)
 
 static void test_string_to_number_empty(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "";
         intmax_t destination = 0;
 
@@ -306,6 +361,8 @@ static void test_string_to_number_empty(void **state)
 
 static void test_string_to_number_zero(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "0";
         intmax_t destination = 0;
         intmax_t expected_number = 0;
@@ -317,6 +374,8 @@ static void test_string_to_number_zero(void **state)
 
 static void test_string_to_number_single_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "e";
         intmax_t destination = 0;
 
@@ -326,6 +385,8 @@ static void test_string_to_number_single_char(void **state)
 
 static void test_string_to_number_double(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "55.5";
         intmax_t destination = 0;
 
@@ -335,6 +396,8 @@ static void test_string_to_number_double(void **state)
 
 static void test_string_splice(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Hello world!";
         const char *expected_string = "world!";
         char *destination = NULL;
@@ -354,6 +417,8 @@ static void test_string_splice(void **state)
 
 static void test_string_splice_null_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         char *destination = NULL;
 
         assert_int_equal(INVALID_INPUT_ERROR,
@@ -362,6 +427,8 @@ static void test_string_splice_null_string(void **state)
 
 static void test_string_splice_large_start(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Test";
         char *destination = NULL;
 
@@ -371,6 +438,8 @@ static void test_string_splice_large_start(void **state)
 
 static void test_string_splice_large_end(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Test";
         char *destination = NULL;
 
@@ -380,6 +449,8 @@ static void test_string_splice_large_end(void **state)
 
 static void test_string_splice_mismatch_start_end(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Test";
         char *destination = NULL;
 
@@ -389,6 +460,8 @@ static void test_string_splice_mismatch_start_end(void **state)
 
 static void test_string_splice_single_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "T";
         char *destination = NULL;
         size_t expected_length = 1;
@@ -405,6 +478,8 @@ static void test_string_splice_single_char(void **state)
 
 static void test_string_splice_zero_start_end(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Something";
         const char *expected_string = "";
         char *destination = NULL;
@@ -422,6 +497,8 @@ static void test_string_splice_zero_start_end(void **state)
 
 static void test_string_strip_surrounding_spaces(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = " Hello world! ";
         const char *expected_string = "Hello world!";
         char *destination = NULL;
@@ -440,6 +517,8 @@ static void test_string_strip_surrounding_spaces(void **state)
 
 static void test_string_strip_surrounding_spaces_tabs(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "\tHello world!  \t";
         const char *expected_string = "Hello world!";
         char *destination = NULL;
@@ -458,6 +537,8 @@ static void test_string_strip_surrounding_spaces_tabs(void **state)
 
 static void test_string_strip_surrounding_spaces_no_spaces(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = "Hello world!";
         char *destination = NULL;
         size_t expected_length = strlen(input);
@@ -475,6 +556,8 @@ static void test_string_strip_surrounding_spaces_no_spaces(void **state)
 
 static void test_string_strip_surrounding_spaces_single_char(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = " A ";
         const char *expected_string = "A";
         char *destination = NULL;
@@ -493,6 +576,8 @@ static void test_string_strip_surrounding_spaces_single_char(void **state)
 
 static void test_string_strip_surrounding_spaces_all_spaces(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = " ";
         char *destination = NULL;
 
@@ -503,6 +588,8 @@ static void test_string_strip_surrounding_spaces_all_spaces(void **state)
 
 static void test_string_strip_surrounding_spaces_null_string(void **state)
 {
+        UNUSED_FUNCTION_PARAM(state);
+
         const char *input = NULL;
         char *destination = NULL;
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -3,6 +3,7 @@
 if (ENABLE_TESTING)
     # Libs required for testing
     option(WITH_EXAMPLES "Don't include cmocka examples" OFF)
+
     add_subdirectory(cmocka)
 endif()
 


### PR DESCRIPTION
Move from defining cflags on the root and propagating them to all vendor programs. Cflags are now defined on the src/ level and they propagate only to app code

Also make POSIX 2008 a requirement since it brings more good than bad. This mean we are moving to using POSIX signals exclusively.

Clean up the code and fix any new warnings caused by the new cflags