### PR TITLE
core/workspace: rename workspace to workspace_list

### DIFF
--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -212,7 +212,7 @@ struct monitor_list *monitor_list_create(struct server_extension *extension,
 }
 
 struct monitor *monitor_create(uint32_t id, xcb_rectangle_t rect,
-                               struct space *space)
+                               struct workspace *workspace)
 {
         struct monitor *monitor = malloc(sizeof(struct monitor));
 
@@ -222,7 +222,7 @@ struct monitor *monitor_create(uint32_t id, xcb_rectangle_t rect,
 
         monitor->id = id;
         monitor->rect = rect;
-        monitor->space = space;
+        monitor->workspace = workspace;
 
         return monitor;
 }

--- a/src/core/monitor.h
+++ b/src/core/monitor.h
@@ -30,7 +30,7 @@ struct monitor {
         // contexts this is unused.
         uint32_t id;
         xcb_rectangle_t rect;
-        struct space *space;
+        struct workspace *workspace;
 };
 
 struct monitor_list {
@@ -44,7 +44,7 @@ const char *server_extension_to_string(enum server_extension_type extension);
 struct monitor_list *monitor_list_create(struct server_extension *extension,
                                          struct list *monitors);
 struct monitor *monitor_create(uint32_t id, xcb_rectangle_t rect,
-                               struct space *space);
+                               struct workspace *workspace);
 enum natwm_error monitor_setup(const struct natwm_state *state,
                                struct monitor_list **result);
 void monitor_list_destroy(struct monitor_list *monitor_list);

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -21,7 +21,7 @@ struct natwm_state *natwm_state_create(void)
         state->ewmh = NULL;
         state->screen = NULL;
         state->monitor_list = NULL;
-        state->workspace = NULL;
+        state->workspace_list = NULL;
         state->config = NULL;
         state->config_path = NULL;
 
@@ -47,8 +47,8 @@ void natwm_state_destroy(struct natwm_state *state)
                 ewmh_destroy(state->ewmh);
         }
 
-        if (state->workspace != NULL) {
-                workspace_destroy(state->workspace);
+        if (state->workspace_list != NULL) {
+                workspace_list_destroy(state->workspace_list);
         }
 
         if (state->monitor_list != NULL) {

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -13,7 +13,7 @@
 
 // Forward declare needed types
 struct monitor_list;
-struct workspace;
+struct workspace_list;
 
 struct natwm_state {
         int screen_num;
@@ -21,7 +21,7 @@ struct natwm_state {
         xcb_ewmh_connection_t *ewmh;
         xcb_screen_t *screen;
         struct monitor_list *monitor_list;
-        struct workspace *workspace;
+        struct workspace_list *workspace_list;
         const struct map *config;
         const char *config_path;
         pthread_mutex_t mutex;

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -11,23 +11,23 @@
 
 #include "state.h"
 
-struct workspace {
+struct workspace_list {
         size_t count;
-        size_t active_space_index;
-        struct space **spaces;
+        size_t active_index;
+        struct workspace **workspaces;
 };
 
-struct space {
-        const char *tag_name;
+struct workspace {
+        const char *name;
         bool is_visible;
         bool is_focused;
         bool is_floating;
         // TODO Windows
 };
 
-struct workspace *workspace_create(size_t count);
-struct space *space_create(const char *tag_name);
-enum natwm_error workspace_init(const struct natwm_state *state,
-                                struct workspace **result);
+struct workspace_list *workspace_list_create(size_t count);
+struct workspace *workspace_create(const char *tag_name);
+enum natwm_error workspace_list_init(const struct natwm_state *state,
+                                     struct workspace_list **result);
+void workspace_list_destroy(struct workspace_list *workspace_list);
 void workspace_destroy(struct workspace *workspace);
-void space_destroy(struct space *space);

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -311,15 +311,15 @@ int main(int argc, char **argv)
 
         state->monitor_list = monitor_list;
 
-        struct workspace *workspace = NULL;
+        struct workspace_list *workspace_list = NULL;
 
-        if (workspace_init(state, &workspace) != NO_ERROR) {
+        if (workspace_list_init(state, &workspace_list) != NO_ERROR) {
                 LOG_ERROR(natwm_logger, "Failed to setup workspaces");
 
                 goto free_and_error;
         }
 
-        state->workspace = workspace;
+        state->workspace_list = workspace_list;
 
         // Attempt to register for substructure events
         if (root_window_subscribe(state) != 0) {


### PR DESCRIPTION
Instead of having a collection of workspaces be named workspace and it's
children "space" have it be a workspace_list which holds a collection of
workspaces

Signed-off-by: Chris Frank <chris@cfrank.org>