### PR TITLE
Feature/monitor offsets

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(common STATIC
     string.h
     tree.c
     tree.h
+    types.h
     util.c
     util.h
 )

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -1,0 +1,14 @@
+// Copyright 2019 Chris Frank
+// Licensed under BSD-3-Clause
+// Refer to the license.txt file included in the root of the project
+
+#pragma once
+
+#include <stdint.h>
+
+struct box_sizes {
+        uint16_t top;
+        uint16_t right;
+        uint16_t bottom;
+        uint16_t left;
+};

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -7,7 +7,40 @@
 #include <sys/select.h>
 #include <unistd.h>
 
+#include "logger.h"
 #include "util.h"
+
+enum natwm_error config_array_to_box_sizes(const struct config_array *array,
+                                           struct box_sizes *result)
+{
+        if (array == NULL || array->length != 4) {
+                return INVALID_INPUT_ERROR;
+        }
+
+        struct box_sizes sizes = {
+                .top = 0,
+                .right = 0,
+                .bottom = 0,
+                .left = 0,
+        };
+
+        for (size_t i = 0; i < 4; ++i) {
+                struct config_value *value = array->values[i];
+
+                if (value == NULL || value->type != NUMBER) {
+                        return INVALID_INPUT_ERROR;
+                }
+        }
+
+        sizes.top = (uint16_t)array->values[0]->data.number;
+        sizes.right = (uint16_t)array->values[1]->data.number;
+        sizes.bottom = (uint16_t)array->values[2]->data.number;
+        sizes.left = (uint16_t)array->values[3]->data.number;
+
+        *result = sizes;
+
+        return NO_ERROR;
+}
 
 /**
  * Get size of a file

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -5,9 +5,17 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 
+#include <core/config/config.h>
+
 #include "error.h"
+#include "types.h"
+
+// Config utilities
+enum natwm_error config_array_to_box_sizes(const struct config_array *array,
+                                           struct box_sizes *result);
 
 // fs utils
 enum natwm_error get_file_size(FILE *file, size_t *size);

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -73,12 +73,14 @@ static void monitor_list_set_offsets(const struct natwm_state *state,
                         break;
                 }
 
-                monitor->rect.x = (monitor->rect.x + offsets.left);
-                monitor->rect.y = (monitor->rect.y + offsets.top);
-                monitor->rect.width = (monitor->rect.width
-                                       - (offsets.left + offsets.right));
-                monitor->rect.height = (monitor->rect.height
-                                        - (offsets.top + offsets.bottom));
+                monitor->rect.x
+                        = (int16_t)(monitor->rect.x + (int16_t)offsets.left);
+                monitor->rect.y
+                        = (int16_t)(monitor->rect.y + (int16_t)offsets.top);
+                monitor->rect.width = monitor->rect.width
+                        - (uint16_t)(offsets.left + offsets.right);
+                monitor->rect.height = monitor->rect.height
+                        - (uint16_t)(offsets.top + offsets.bottom);
 
                 ++index;
         }

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -75,10 +75,8 @@ static void monitor_list_set_offsets(const struct natwm_state *state,
 
                 // This has a possibility of overflowing if the user
                 // imputs silly data into their configuration file.
-                monitor->rect.x
-                        = (int16_t)(monitor->rect.x + (int16_t)offsets.left);
-                monitor->rect.y
-                        = (int16_t)(monitor->rect.y + (int16_t)offsets.top);
+                monitor->rect.x = (int16_t)(monitor->rect.x + offsets.left);
+                monitor->rect.y = (int16_t)(monitor->rect.y + offsets.top);
                 monitor->rect.width = (uint16_t)(
                         monitor->rect.width - (offsets.left + offsets.right));
                 monitor->rect.height = (uint16_t)(

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -74,7 +74,7 @@ static void monitor_list_set_offsets(const struct natwm_state *state,
                 }
 
                 // This has a possibility of overflowing if the user
-                // imputs silly data into their configuration file.
+                // inputs silly data into their configuration file.
                 monitor->rect.x = (int16_t)(monitor->rect.x + offsets.left);
                 monitor->rect.y = (int16_t)(monitor->rect.y + offsets.top);
                 monitor->rect.width = (uint16_t)(

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -73,14 +73,16 @@ static void monitor_list_set_offsets(const struct natwm_state *state,
                         break;
                 }
 
+                // This has a possibility of overflowing if the user
+                // imputs silly data into their configuration file.
                 monitor->rect.x
                         = (int16_t)(monitor->rect.x + (int16_t)offsets.left);
                 monitor->rect.y
                         = (int16_t)(monitor->rect.y + (int16_t)offsets.top);
-                monitor->rect.width = monitor->rect.width
-                        - (uint16_t)(offsets.left + offsets.right);
-                monitor->rect.height = monitor->rect.height
-                        - (uint16_t)(offsets.top + offsets.bottom);
+                monitor->rect.width = (uint16_t)(
+                        monitor->rect.width - (offsets.left + offsets.right));
+                monitor->rect.height = (uint16_t)(
+                        monitor->rect.height - (offsets.top + offsets.bottom));
 
                 ++index;
         }


### PR DESCRIPTION
In the situation you have a bar on one side of a monitor it would be nice to be able to 'mark' that area as occupied and have the window manager not place anything there. This PR gives the user that ability.

In a hypothetical situation where you have two monitors, and on the first monitor you want to place a 25px bar at the top of the screen, you can use the following configuration:

```
monitor.offsets = [
    [25, 0, 0, 0],
    [0, 0, 0, 0],
]
```

This will add `25px` of padding to the top of the first monitor (monitor is decided by looking at the array position of the offset array)

The second monitor will be left alone.

**One thing to note, the bar must be set up with `XCB_CW_OVERRIDE_REDIRECT` (or something of the same effect**

This is needed because otherwise the window would be placed within the monitor region, negating any benefit of this change. It must tell us to ignore it, and place itself correctly.