### PR TITLE
Feature/map tiles only when visible

### DIFF
--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -25,6 +25,8 @@
 
 #define NATWM_CONFIG_FILE "natwm/config"
 
+#define NATWM_WORKSPACE_COUNT 10
+
 #define UNFOCUSED_BORDER_WIDTH_CONFIG_STRING "window.unfocused.border_width"
 #define FOCUSED_BORDER_WIDTH_CONFIG_STRING "window.focused.border_width"
 #define URGENT_BORDER_WIDTH_CONFIG_STRING "window.urgent.border_width"
@@ -41,5 +43,3 @@
         "window.unfocused.background_color"
 #define URGENT_BACKGROUND_COLOR_CONFIG_STRING "window.urgent.background_color"
 #define STICKY_BACKGROUND_COLOR_CONFIG_STRING "window.sticky.background_color"
-
-#define NATWM_WORKSPACE_COUNT 10

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -17,7 +17,8 @@ static enum natwm_error
 event_handle_map_request(const struct natwm_state *state,
                          xcb_map_request_event_t *event)
 {
-        struct tile *tile = tile_register_client(state, &event->window);
+        xcb_window_t window = event->window;
+        struct tile *tile = tile_register_client(state, &window);
 
         if (tile == NULL) {
                 return RESOLUTION_FAILURE;

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -2,6 +2,7 @@
 // Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
+#include <string.h>
 #include <xcb/randr.h>
 #include <xcb/xinerama.h>
 
@@ -284,6 +285,26 @@ monitor_list_get_active_monitor(const struct monitor_list *monitor_list)
 
                 if (monitor->workspace != NULL
                     && monitor->workspace->is_focused) {
+                        return monitor;
+                }
+        }
+
+        return NULL;
+}
+
+struct monitor *
+monitor_list_get_workspace_monitor(const struct monitor_list *monitor_list,
+                                   const struct workspace *workspace)
+{
+        LIST_FOR_EACH(monitor_list->monitors, monitor_item)
+        {
+                struct monitor *monitor = (struct monitor *)monitor_item->data;
+
+                if (monitor->workspace == NULL) {
+                        continue;
+                }
+
+                if (strcmp(monitor->workspace->name, workspace->name) == 0) {
                         return monitor;
                 }
         }

--- a/src/core/monitor.h
+++ b/src/core/monitor.h
@@ -45,6 +45,9 @@ struct monitor_list *monitor_list_create(struct server_extension *extension,
                                          struct list *monitors);
 struct monitor *
 monitor_list_get_active_monitor(const struct monitor_list *monitor_list);
+struct monitor *
+monitor_list_get_workspace_monitor(const struct monitor_list *monitor_list,
+                                   const struct workspace *workspace);
 struct monitor *monitor_create(uint32_t id, xcb_rectangle_t rect,
                                struct workspace *workspace);
 enum natwm_error monitor_setup(const struct natwm_state *state,

--- a/src/core/tile.h
+++ b/src/core/tile.h
@@ -54,9 +54,13 @@ struct tile {
         enum tile_state state;
 };
 
+// Forward declare workspace
+struct workspace;
+
 struct tile *tile_create(xcb_window_t *window);
-enum natwm_error get_next_tile_rect(const struct natwm_state *state,
-                                    xcb_rectangle_t *result);
+enum natwm_error get_next_tiled_rect(const struct natwm_state *state,
+                                     const struct workspace *workspace,
+                                     xcb_rectangle_t *result);
 struct tile *tile_register_client(const struct natwm_state *state,
                                   xcb_window_t *client);
 enum natwm_error attach_tiles_to_workspace(const struct natwm_state *state);

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -12,6 +12,19 @@
 #include "tile.h"
 #include "workspace.h"
 
+static const char *DEFAULT_WORKSPACE_NAMES[10] = {
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+};
+
 static void workspace_tiles_destroy_callback(struct leaf *leaf)
 {
         if (leaf != NULL && leaf->data != NULL) {
@@ -115,7 +128,8 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
 
                 // We don't have a user specified tag name for this space
                 if (workspace_names == NULL || i >= workspace_names->length) {
-                        workspace = workspace_create(NULL);
+                        const char *name = DEFAULT_WORKSPACE_NAMES[i];
+                        workspace = workspace_create(name);
 
                         if (workspace == NULL) {
                                 workspace_list_destroy(workspace_list);

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -389,6 +389,8 @@ int main(int argc, char **argv)
         return EXIT_SUCCESS;
 
 free_and_error:
+        LOG_CRITICAL(natwm_logger, "Encountered error. Closing...");
+
         free(arg_options);
         natwm_state_destroy(state);
         destroy_logger(natwm_logger);


### PR DESCRIPTION
Instead of layering tiles on top of each other only map a single tile to each visible workspace.

Also make sure that each tile is mapped to the correct rect by grabbing the monitor rect from each visible workspace.

Screenshot from running natively for the first time: 
![2020-01-05-224457_3840x1080_scrot](https://user-images.githubusercontent.com/2308484/71800801-e69d5480-300d-11ea-9c4d-d83dbf9bd3d4.png)
