### PR TITLE
Feature/some ewmh implementations

### DIFF
--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -27,6 +27,8 @@
 
 #define NATWM_WORKSPACE_COUNT 10
 
+#define NATWM_WORKSPACE_NAME_MAX_LEN 50
+
 #define UNFOCUSED_BORDER_WIDTH_CONFIG_STRING "window.unfocused.border_width"
 #define FOCUSED_BORDER_WIDTH_CONFIG_STRING "window.focused.border_width"
 #define URGENT_BORDER_WIDTH_CONFIG_STRING "window.urgent.border_width"

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -78,7 +78,6 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_CURRENT_DESKTOP,
                 state->ewmh->_NET_DESKTOP_NAMES,
                 state->ewmh->_NET_ACTIVE_WINDOW,
-                state->ewmh->_NET_WORKAREA,
                 state->ewmh->_NET_SUPPORTING_WM_CHECK,
                 // Root messages
                 state->ewmh->_NET_CLOSE_WINDOW,

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -157,6 +157,27 @@ void ewmh_update_desktop_viewport(const struct natwm_state *state)
                                       viewports);
 }
 
+void ewmh_update_desktop_names(const struct natwm_state *state,
+                               const struct workspace_list *list)
+{
+        char names[(NATWM_WORKSPACE_NAME_MAX_LEN * list->count) + list->count];
+        size_t pos = 0;
+
+        for (size_t i = 0; i < list->count; ++i) {
+                const char *name = list->workspaces[i]->name;
+                size_t name_length = strlen(name);
+
+                memcpy(names + pos, name, name_length);
+
+                names[pos + name_length] = '\0';
+
+                pos += (name_length + 1);
+        }
+
+        xcb_ewmh_set_desktop_names(
+                state->ewmh, state->screen_num, (uint32_t)(pos - 1), names);
+}
+
 void ewmh_update_current_desktop(const struct natwm_state *state,
                                  size_t current_index)
 {

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -7,7 +7,6 @@
 #include <unistd.h>
 
 #include <common/constants.h>
-#include <common/logger.h>
 
 #include "ewmh.h"
 #include "monitor.h"
@@ -134,14 +133,14 @@ void ewmh_init(const struct natwm_state *state)
                                         (uint32_t)NATWM_WORKSPACE_COUNT);
 }
 
-void ewmh_update_desktop_viewport(const struct natwm_state *state)
+void ewmh_update_desktop_viewport(const struct natwm_state *state,
+                                  const struct monitor_list *list)
 {
-        size_t num_monitors = state->monitor_list->monitors->size;
+        size_t num_monitors = list->monitors->size;
         xcb_ewmh_coordinates_t viewports[num_monitors];
-
         size_t index = 0;
 
-        LIST_FOR_EACH(state->monitor_list->monitors, monitor_item)
+        LIST_FOR_EACH(list->monitors, monitor_item)
         {
                 struct monitor *monitor = (struct monitor *)monitor_item->data;
 

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -74,7 +74,6 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_CLIENT_LIST,
                 state->ewmh->_NET_CLIENT_LIST_STACKING,
                 state->ewmh->_NET_NUMBER_OF_DESKTOPS,
-                state->ewmh->_NET_DESKTOP_GEOMETRY,
                 state->ewmh->_NET_DESKTOP_VIEWPORT,
                 state->ewmh->_NET_CURRENT_DESKTOP,
                 state->ewmh->_NET_DESKTOP_NAMES,

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -134,22 +134,18 @@ void ewmh_init(const struct natwm_state *state)
         xcb_ewmh_set_number_of_desktops(state->ewmh,
                                         state->screen_num,
                                         (uint32_t)NATWM_WORKSPACE_COUNT);
-
-        ewmh_update_desktop_viewport(state);
 }
 
 void ewmh_update_desktop_viewport(const struct natwm_state *state)
 {
-        size_t num_desktops = state->monitor_list->monitors->size;
-        xcb_ewmh_coordinates_t viewports[num_desktops];
+        size_t num_monitors = state->monitor_list->monitors->size;
+        xcb_ewmh_coordinates_t viewports[num_monitors];
 
         size_t index = 0;
 
         LIST_FOR_EACH(state->monitor_list->monitors, monitor_item)
         {
                 struct monitor *monitor = (struct monitor *)monitor_item->data;
-
-                assert(index < num_desktops);
 
                 viewports[index].x = (uint32_t)monitor->rect.x;
                 viewports[index].y = (uint32_t)monitor->rect.y;
@@ -159,8 +155,17 @@ void ewmh_update_desktop_viewport(const struct natwm_state *state)
 
         xcb_ewmh_set_desktop_viewport(state->ewmh,
                                       state->screen_num,
-                                      (uint32_t)num_desktops,
+                                      (uint32_t)num_monitors,
                                       viewports);
+}
+
+void ewmh_update_current_desktop(const struct natwm_state *state,
+                                 size_t current_index)
+{
+        assert(current_index < NATWM_WORKSPACE_COUNT);
+
+        xcb_ewmh_set_current_desktop(
+                state->ewmh, state->screen_num, (uint32_t)current_index);
 }
 
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection)

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -2,10 +2,16 @@
 // Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
+#include <assert.h>
 #include <string.h>
 #include <unistd.h>
 
+#include <common/constants.h>
+#include <common/logger.h>
+
 #include "ewmh.h"
+#include "monitor.h"
+#include "workspace.h"
 
 // Create a simple window for the _NET_SUPPORTING_WM_CHECK property
 //
@@ -55,15 +61,8 @@ xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection)
 
 void ewmh_init(const struct natwm_state *state)
 {
-        // Base info
         pid_t pid = getpid();
         size_t wm_name_len = strlen(NATWM_VERSION_STRING);
-
-        xcb_ewmh_set_wm_pid(state->ewmh, state->screen->root, (uint32_t)pid);
-        xcb_ewmh_set_wm_name(state->ewmh,
-                             state->screen->root,
-                             (uint32_t)wm_name_len,
-                             NATWM_VERSION_STRING);
 
         // A list of supported atoms
         //
@@ -76,7 +75,6 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_CLIENT_LIST_STACKING,
                 state->ewmh->_NET_NUMBER_OF_DESKTOPS,
                 state->ewmh->_NET_DESKTOP_GEOMETRY,
-                // We don't support large desktops - this will always be 0,0
                 state->ewmh->_NET_DESKTOP_VIEWPORT,
                 state->ewmh->_NET_CURRENT_DESKTOP,
                 state->ewmh->_NET_DESKTOP_NAMES,
@@ -116,6 +114,12 @@ void ewmh_init(const struct natwm_state *state)
         xcb_ewmh_set_supported(
                 state->ewmh, state->screen_num, (uint32_t)len, net_atoms);
 
+        xcb_ewmh_set_wm_pid(state->ewmh, state->screen->root, (uint32_t)pid);
+        xcb_ewmh_set_wm_name(state->ewmh,
+                             state->screen->root,
+                             (uint32_t)wm_name_len,
+                             NATWM_VERSION_STRING);
+
         xcb_window_t supporting_win = create_supporting_window(state);
 
         xcb_ewmh_set_supporting_wm_check(
@@ -126,6 +130,37 @@ void ewmh_init(const struct natwm_state *state)
                              supporting_win,
                              (uint32_t)wm_name_len,
                              NATWM_VERSION_STRING);
+
+        xcb_ewmh_set_number_of_desktops(state->ewmh,
+                                        state->screen_num,
+                                        (uint32_t)NATWM_WORKSPACE_COUNT);
+
+        ewmh_update_desktop_viewport(state);
+}
+
+void ewmh_update_desktop_viewport(const struct natwm_state *state)
+{
+        size_t num_desktops = state->monitor_list->monitors->size;
+        xcb_ewmh_coordinates_t viewports[num_desktops];
+
+        size_t index = 0;
+
+        LIST_FOR_EACH(state->monitor_list->monitors, monitor_item)
+        {
+                struct monitor *monitor = (struct monitor *)monitor_item->data;
+
+                assert(index < num_desktops);
+
+                viewports[index].x = (uint32_t)monitor->rect.x;
+                viewports[index].y = (uint32_t)monitor->rect.y;
+
+                ++index;
+        }
+
+        xcb_ewmh_set_desktop_viewport(state->ewmh,
+                                      state->screen_num,
+                                      (uint32_t)num_desktops,
+                                      viewports);
 }
 
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection)

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -159,6 +159,14 @@ void ewmh_update_desktop_viewport(const struct natwm_state *state,
 void ewmh_update_desktop_names(const struct natwm_state *state,
                                const struct workspace_list *list)
 {
+        // Should never happen
+        if (list->count < 1) {
+                xcb_ewmh_set_desktop_names(
+                        state->ewmh, state->screen_num, 0, NULL);
+
+                return;
+        }
+
         char names[(NATWM_WORKSPACE_NAME_MAX_LEN * list->count) + list->count];
         size_t pos = 0;
 

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -10,4 +10,5 @@
 
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
+void ewmh_update_desktop_viewport(const struct natwm_state *state);
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection);

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -11,6 +11,8 @@
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
 void ewmh_update_desktop_viewport(const struct natwm_state *state);
+void ewmh_update_desktop_names(const struct natwm_state *state,
+                               const struct workspace_list *list);
 void ewmh_update_current_desktop(const struct natwm_state *state,
                                  size_t current_index);
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection);

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -11,4 +11,6 @@
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
 void ewmh_update_desktop_viewport(const struct natwm_state *state);
+void ewmh_update_current_desktop(const struct natwm_state *state,
+                                 size_t current_index);
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection);

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -10,7 +10,8 @@
 
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
-void ewmh_update_desktop_viewport(const struct natwm_state *state);
+void ewmh_update_desktop_viewport(const struct natwm_state *state,
+                                  const struct monitor_list *list);
 void ewmh_update_desktop_names(const struct natwm_state *state,
                                const struct workspace_list *list);
 void ewmh_update_current_desktop(const struct natwm_state *state,

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -11,6 +11,7 @@
 #include <common/util.h>
 
 #include "config/config.h"
+#include "ewmh.h"
 #include "monitor.h"
 #include "randr.h"
 #include "xinerama.h"
@@ -382,6 +383,9 @@ enum natwm_error monitor_setup(const struct natwm_state *state,
         }
 
         monitor_list_set_offsets(state, monitor_list);
+
+        // Initialize the desktop viewport
+        ewmh_update_desktop_viewport(state, monitor_list);
 
         *result = monitor_list;
 

--- a/src/core/tile.c
+++ b/src/core/tile.c
@@ -33,6 +33,8 @@ static enum natwm_error get_window_rect(xcb_connection_t *connection,
 
         *result = rect;
 
+        free(reply);
+
         return NO_ERROR;
 }
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -8,6 +8,7 @@
 #include <common/logger.h>
 
 #include "config/config.h"
+#include "ewmh.h"
 #include "monitor.h"
 #include "tile.h"
 #include "workspace.h"
@@ -53,6 +54,7 @@ static void attach_to_monitors(struct monitor_list *monitor_list,
 
                 // Focus on the first monitor
                 if (index == 0) {
+                        workspace_list->active_index = 0;
                         workspace->is_focused = true;
                 }
 
@@ -163,6 +165,8 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
         }
 
         attach_to_monitors(state->monitor_list, workspace_list);
+
+        ewmh_update_current_desktop(state, workspace_list->active_index);
 
         *result = workspace_list;
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -89,7 +89,7 @@ workspace_init(const struct config_array *workspace_names, size_t index)
                 return workspace_create(name);
         }
 
-        if (strlen(name_value->data.string) >= NATWM_WORKSPACE_NAME_MAX_LEN) {
+        if (strlen(name_value->data.string) > NATWM_WORKSPACE_NAME_MAX_LEN) {
                 LOG_WARNING(
                         natwm_logger,
                         "Workspace name '%s' is too long. Max length is %zu",
@@ -178,6 +178,7 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
         attach_to_monitors(state->monitor_list, workspace_list);
 
         ewmh_update_current_desktop(state, workspace_list->active_index);
+        ewmh_update_desktop_names(state, workspace_list);
 
         *result = workspace_list;
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included in the root of the project
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <common/constants.h>
 #include <common/logger.h>
@@ -63,6 +64,42 @@ static void attach_to_monitors(struct monitor_list *monitor_list,
 
                 ++index;
         }
+}
+
+/**
+ * Given a list of workspace names attempt to find a user specified workspace
+ * name and initialize a new workspace with that name. If there is no name, or
+ * it is invalid then create a new workspace with the default name
+ */
+static struct workspace *
+workspace_init(const struct config_array *workspace_names, size_t index)
+{
+        const char *name = DEFAULT_WORKSPACE_NAMES[index];
+
+        if (workspace_names == NULL || index >= workspace_names->length) {
+                return workspace_create(name);
+        }
+
+        const struct config_value *name_value = workspace_names->values[index];
+
+        if (name_value == NULL || name_value->type != STRING) {
+                LOG_WARNING(
+                        natwm_logger, "Ignoring invalid workspace name", name);
+
+                return workspace_create(name);
+        }
+
+        if (strlen(name_value->data.string) >= NATWM_WORKSPACE_NAME_MAX_LEN) {
+                LOG_WARNING(
+                        natwm_logger,
+                        "Workspace name '%s' is too long. Max length is %zu",
+                        name_value->data.string,
+                        NATWM_WORKSPACE_NAME_MAX_LEN);
+
+                return workspace_create(name);
+        }
+
+        return workspace_create(name_value->data.string);
 }
 
 struct workspace_list *workspace_list_create(size_t count)
@@ -126,39 +163,13 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
         }
 
         for (size_t i = 0; i < NATWM_WORKSPACE_COUNT; ++i) {
-                struct workspace *workspace = NULL;
+                struct workspace *workspace
+                        = workspace_init(workspace_names, i);
 
-                // We don't have a user specified tag name for this space
-                if (workspace_names == NULL || i >= workspace_names->length) {
-                        const char *name = DEFAULT_WORKSPACE_NAMES[i];
-                        workspace = workspace_create(name);
+                if (workspace == NULL) {
+                        workspace_list_destroy(workspace_list);
 
-                        if (workspace == NULL) {
-                                workspace_list_destroy(workspace_list);
-
-                                return MEMORY_ALLOCATION_ERROR;
-                        }
-                } else {
-                        const struct config_value *name_value
-                                = workspace_names->values[i];
-
-                        if (name_value == NULL || name_value->type != STRING) {
-                                LOG_ERROR(natwm_logger,
-                                          "Encountered invalid workspace tag "
-                                          "name");
-
-                                workspace_list_destroy(workspace_list);
-
-                                return INVALID_INPUT_ERROR;
-                        }
-
-                        workspace = workspace_create(name_value->data.string);
-
-                        if (workspace == NULL) {
-                                workspace_list_destroy(workspace_list);
-
-                                return MEMORY_ALLOCATION_ERROR;
-                        }
+                        return MEMORY_ALLOCATION_ERROR;
                 }
 
                 workspace_list->workspaces[i] = workspace;

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -314,6 +314,17 @@ int main(int argc, char **argv)
 
         state->screen = default_screen;
 
+        xcb_ewmh_connection_t *ewmh = ewmh_create(xcb);
+
+        if (ewmh == NULL) {
+                goto free_and_error;
+        }
+
+        state->ewmh = ewmh;
+
+        // Initialize ewmh hinting
+        ewmh_init(state);
+
         struct monitor_list *monitor_list = NULL;
 
         if (monitor_setup(state, &monitor_list) != NO_ERROR) {
@@ -321,6 +332,9 @@ int main(int argc, char **argv)
         }
 
         state->monitor_list = monitor_list;
+
+        // Use the monitor list we just initialized to set the desktop viewport
+        ewmh_update_desktop_viewport(state);
 
         struct workspace_list *workspace_list = NULL;
 
@@ -357,17 +371,6 @@ int main(int argc, char **argv)
 
                 goto free_and_error;
         }
-
-        xcb_ewmh_connection_t *ewmh = ewmh_create(xcb);
-
-        if (ewmh == NULL) {
-                goto free_and_error;
-        }
-
-        state->ewmh = ewmh;
-
-        // Initialize ewmh hinting
-        ewmh_init(state);
 
         program_status = RUNNING;
 

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -333,9 +333,6 @@ int main(int argc, char **argv)
 
         state->monitor_list = monitor_list;
 
-        // Use the monitor list we just initialized to set the desktop viewport
-        ewmh_update_desktop_viewport(state);
-
         struct workspace_list *workspace_list = NULL;
 
         if (workspace_list_init(state, &workspace_list) != NO_ERROR) {


### PR DESCRIPTION
This PR adds a few more ewmh implementations:

**Implemented:**
_NET_NUMBER_OF_DESKTOPS
_NET_DESKTOP_VIEWPORT
_NET_CURRENT_DESKTOP
_NET_DESKTOP_NAMES

**Removed:**
_NET_DESKTOP_GEOMETRY
_NET_WORKAREA

Also while implementing `_NET_DESKTOP_NAMES` I decided to limit the workspace tag name to 50 characters. This is not a hard limit and can be changed in the future, but for now it seems reasonable.