### PR TITLE
Feature/support non string map keys

### DIFF
--- a/src/common/map.c
+++ b/src/common/map.c
@@ -150,7 +150,8 @@ static enum natwm_error map_search(const struct map *map, const void *key,
 
                 struct map_entry *entry = map->entries[current_index];
 
-                if (!is_entry_present(entry) || strcmp(key, entry->key) != 0) {
+                if (!is_entry_present(entry)
+                    || memcmp(key, entry->key, key_size) != 0) {
                         current_index += 1;
 
                         continue;
@@ -502,12 +503,26 @@ enum natwm_error map_delete(struct map *map, const void *key)
 // Set a hashing function for use when inserting and re-hashing entries
 int map_set_hash_function(struct map *map, map_hash_function_t function)
 {
-        if (map->hash_function != NULL && map->bucket_count > 0) {
+        if (map->bucket_count > 0) {
                 // Since we have entries we can't use a different hashing func
                 return -1;
         }
 
         map->hash_function = function;
+
+        return 0;
+}
+
+// Set the key sizing function.
+int map_set_key_size_function(struct map *map, map_key_size_function_t function)
+{
+        if (map->bucket_count > 0) {
+                // Since we have already added entries to the map we can't
+                // change how we determine key size.
+                return -1;
+        }
+
+        map->key_size_function = function;
 
         return 0;
 }

--- a/src/common/map.c
+++ b/src/common/map.c
@@ -18,10 +18,17 @@ static enum natwm_error map_insert_entry(struct map *map,
 
 // Default map hashing function
 // Uses Murmur v3 32bit
-static ATTR_CONST uint32_t default_key_hash(const char *key)
+static ATTR_CONST uint32_t default_hash_function(const void *key, size_t size)
 {
         // TODO: Should thought be put into a seed for the hash
-        return hash_murmur3_32(key, strlen(key), 0);
+        return hash_murmur3_32(key, size, 0);
+}
+
+// Default key size function
+// This will return the correct size of a string key
+static size_t default_key_size_function(const void *key)
+{
+        return strlen(key);
 }
 
 // Given a map_entry determine if it holds valid data and is present
@@ -124,7 +131,7 @@ static enum natwm_error map_probe(struct map *map, struct map_entry *entry,
         return CAPACITY_ERROR;
 }
 
-static enum natwm_error map_search(const struct map *map, const char *key,
+static enum natwm_error map_search(const struct map *map, const void *key,
                                    uint32_t *index)
 {
         if (key == NULL || index == NULL) {
@@ -132,7 +139,9 @@ static enum natwm_error map_search(const struct map *map, const char *key,
         }
 
         // Initialize index with initial bucket index
-        uint32_t current_index = map->hash_function(key) % map->length;
+        size_t key_size = map->key_size_function(key);
+        uint32_t current_index
+                = map->hash_function(key, key_size) % map->length;
 
         for (size_t i = 0; i <= map->length; ++i) {
                 if ((current_index) >= map->length) {
@@ -314,7 +323,7 @@ static enum natwm_error map_insert_entry(struct map *map,
 }
 
 // Given a hash, key, and value construct a map entry
-enum natwm_error entry_init(uint32_t hash, const char *key, void *value,
+enum natwm_error entry_init(uint32_t hash, const void *key, void *value,
                             struct map_entry **dest)
 {
         if (key == NULL || dest == NULL) {
@@ -378,7 +387,8 @@ struct map *map_init(void)
                 return NULL;
         }
 
-        map->hash_function = default_key_hash;
+        map->hash_function = default_hash_function;
+        map->key_size_function = default_key_size_function;
         map->free_function = NULL;
         map->setting_flags = MAP_FLAG_IGNORE_THRESHOLDS_EMPTY;
         map->event_flags = EVENT_FLAG_NORMAL;
@@ -408,14 +418,15 @@ void map_destroy(struct map *map)
 }
 
 // Insert an entry into a map
-enum natwm_error map_insert(struct map *map, const char *key, void *value)
+enum natwm_error map_insert(struct map *map, const void *key, void *value)
 {
         if (key == NULL) {
                 return GENERIC_ERROR;
         }
 
         struct map_entry *entry = NULL;
-        uint32_t hash = map->hash_function(key);
+        size_t key_size = map->key_size_function(key);
+        uint32_t hash = map->hash_function(key, key_size);
         enum natwm_error error = entry_init(hash, key, value, &entry);
 
         if (error != NO_ERROR) {
@@ -425,7 +436,7 @@ enum natwm_error map_insert(struct map *map, const char *key, void *value)
         return map_insert_entry(map, entry);
 }
 
-struct map_entry *map_get(const struct map *map, const char *key)
+struct map_entry *map_get(const struct map *map, const void *key)
 {
         uint32_t index = 0;
 
@@ -437,7 +448,7 @@ struct map_entry *map_get(const struct map *map, const char *key)
 }
 
 // TODO: Add resize when threshold goes below MAP_LOAD_FACTOR_LOW
-enum natwm_error map_delete(struct map *map, const char *key)
+enum natwm_error map_delete(struct map *map, const void *key)
 {
         uint32_t dest_index = 0;
         enum natwm_error err = map_search(map, key, &dest_index);
@@ -527,7 +538,7 @@ void map_remove_setting_flag(struct map *map, enum map_settings flag)
 /**
  * Type specific getters
  */
-uint32_t map_get_uint32(const struct map *map, const char *key,
+uint32_t map_get_uint32(const struct map *map, const void *key,
                         enum natwm_error *error)
 {
         struct map_entry *entry = map_get(map, key);

--- a/src/common/map.h
+++ b/src/common/map.h
@@ -33,7 +33,10 @@
  */
 
 // Function which takes a key and returns a hash
-typedef uint32_t (*map_hash_function_t)(const char *key);
+typedef uint32_t (*map_hash_function_t)(const void *key, size_t size);
+
+// Function for finding the size of a supplied key
+typedef size_t (*map_key_size_function_t)(const void *key);
 
 // Function which takes data and frees the memory allocated for it
 typedef void (*map_entry_free_function_t)(void *data);
@@ -77,20 +80,21 @@ struct map {
         struct map_entry **entries;
         pthread_mutex_t mutex;
         map_hash_function_t hash_function;
+        map_key_size_function_t key_size_function;
         map_entry_free_function_t free_function;
         enum map_settings setting_flags;
         enum map_events event_flags;
 };
 
-enum natwm_error entry_init(uint32_t hash, const char *key, void *value,
+enum natwm_error entry_init(uint32_t hash, const void *key, void *value,
                             struct map_entry **dest);
 void map_entry_destroy(const struct map *map, struct map_entry *entry);
 
 struct map *map_init(void);
 void map_destroy(struct map *map);
-enum natwm_error map_insert(struct map *map, const char *key, void *value);
-struct map_entry *map_get(const struct map *map, const char *key);
-enum natwm_error map_delete(struct map *map, const char *key);
+enum natwm_error map_insert(struct map *map, const void *key, void *value);
+struct map_entry *map_get(const struct map *map, const void *key);
+enum natwm_error map_delete(struct map *map, const void *key);
 
 int map_set_hash_function(struct map *map, map_hash_function_t function);
 void map_set_entry_free_function(struct map *map,
@@ -98,5 +102,5 @@ void map_set_entry_free_function(struct map *map,
 void map_set_setting_flag(struct map *map, enum map_settings flag);
 void map_remove_setting_flag(struct map *map, enum map_settings flag);
 
-uint32_t map_get_uint32(const struct map *map, const char *key,
+uint32_t map_get_uint32(const struct map *map, const void *key,
                         enum natwm_error *error);

--- a/src/common/map.h
+++ b/src/common/map.h
@@ -69,7 +69,7 @@ struct map_entry {
         // Pro: Smaller entry memory footprint
         // Con: Increased computation when calculating DIB
         uint32_t hash;
-        const char *key;
+        const void *key;
         void *value;
 };
 
@@ -97,6 +97,8 @@ struct map_entry *map_get(const struct map *map, const void *key);
 enum natwm_error map_delete(struct map *map, const void *key);
 
 int map_set_hash_function(struct map *map, map_hash_function_t function);
+int map_set_key_size_function(struct map *map,
+                              map_key_size_function_t function);
 void map_set_entry_free_function(struct map *map,
                                  map_entry_free_function_t function);
 void map_set_setting_flag(struct map *map, enum map_settings flag);

--- a/src/test/test_map.c
+++ b/src/test/test_map.c
@@ -203,6 +203,47 @@ static void test_map_insert_multiple_non_string_key(void **state)
         assert_int_equal(expected_key_second, *(size_t *)second_entry->key);
 }
 
+static void test_map_insert_duplicate_non_string_key(void **state)
+{
+        UNUSED_FUNCTION_PARAM(state);
+
+        struct map *map = map_init();
+
+        if (map == NULL) {
+                assert_true(false);
+        }
+
+        map_set_key_size_function(map, determine_number_key_size);
+
+        size_t expected_key = 1234;
+        const char *expected_value_first = "first value";
+        const char *expected_value_second = "second value";
+        size_t expected_bucket_count = 1;
+
+        assert_int_equal(
+                NO_ERROR,
+                map_insert(map, &expected_key, (char *)expected_value_first));
+        assert_int_equal(expected_bucket_count, map->bucket_count);
+
+        struct map_entry *entry_first = map_get(map, &expected_key);
+
+        assert_non_null(entry_first);
+        assert_string_equal(expected_value_first,
+                            (const char *)entry_first->value);
+        assert_int_equal(expected_key, *(size_t *)entry_first->key);
+        assert_int_equal(
+                NO_ERROR,
+                map_insert(map, &expected_key, (char *)expected_value_second));
+        assert_int_equal(expected_bucket_count, map->bucket_count);
+
+        struct map_entry *entry_second = map_get(map, &expected_key);
+
+        assert_non_null(entry_second);
+        assert_string_equal(expected_value_second,
+                            (const char *)entry_second->value);
+        assert_int_equal(expected_key, *(size_t *)entry_second->key);
+}
+
 static void test_map_insert_load_factor_disabled(void **state)
 {
         struct map *map = *(struct map **)state;
@@ -466,6 +507,7 @@ int main(void)
                         test_map_insert_null_key, test_setup, test_teardown),
                 cmocka_unit_test(test_map_insert_non_string_key),
                 cmocka_unit_test(test_map_insert_multiple_non_string_key),
+                cmocka_unit_test(test_map_insert_duplicate_non_string_key),
                 cmocka_unit_test_setup_teardown(
                         test_map_insert_load_factor_disabled,
                         test_setup,

--- a/src/test/test_map.c
+++ b/src/test/test_map.c
@@ -1,4 +1,5 @@
-// Copyright 2019 Chris Fraexpected_key// Licensed under BSD-3-Clause
+// Copyright 2019 Chris Frank
+// Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
 #include <setjmp.h>
@@ -159,6 +160,8 @@ static void test_map_insert_non_string_key(void **state)
         assert_non_null(entry);
         assert_int_equal(expected_key, *(size_t *)entry->key);
         assert_string_equal(expected_value, (const char *)entry->value);
+
+        map_destroy(map);
 }
 
 static void test_map_insert_multiple_non_string_key(void **state)
@@ -201,6 +204,8 @@ static void test_map_insert_multiple_non_string_key(void **state)
         assert_string_equal(expected_value_second,
                             (const char *)second_entry->value);
         assert_int_equal(expected_key_second, *(size_t *)second_entry->key);
+
+        map_destroy(map);
 }
 
 static void test_map_insert_duplicate_non_string_key(void **state)
@@ -242,6 +247,8 @@ static void test_map_insert_duplicate_non_string_key(void **state)
         assert_string_equal(expected_value_second,
                             (const char *)entry_second->value);
         assert_int_equal(expected_key, *(size_t *)entry_second->key);
+
+        map_destroy(map);
 }
 
 static void test_map_insert_load_factor_disabled(void **state)


### PR DESCRIPTION
This will allow us to store data which doesn't have a string key. The most obvious being caching window ids and their workspace position