### PR TITLE
Feature/add client to workspace

### DIFF
--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -23,6 +23,10 @@
                 (*dest) = value;                                               \
         }
 
+// Copied from https://github.com/openbsd/src/blob/master/sys/sys/param.h
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 #define NATWM_CONFIG_FILE "natwm/natwm.config"
 
 #define NATWM_WORKSPACE_COUNT 10

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -126,10 +126,9 @@ struct client *client_register_window(struct natwm_state *state,
                 return NULL;
         }
 
+        // Adjust window rect to fit workspace monitor
         xcb_rectangle_t normalized_rect
                 = client_clamp_rect_to_monitor(rect, workspace_monitor->rect);
-
-        // Adjust window rect for workspace monitor
 
         struct client *client = client_create(window, normalized_rect);
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -39,8 +39,11 @@ struct client {
 };
 
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect);
-struct client *client_register_window(const struct natwm_state *state,
+struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
+void client_set_focused(const struct natwm_state *state, struct client *client);
+void client_set_unfocused(const struct natwm_state *state,
+                          struct client *client);
 
 enum natwm_error client_theme_create(const struct map *config_map,
                                      struct client_theme **result);

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -41,6 +41,8 @@ struct client {
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect);
 struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
+xcb_rectangle_t client_clamp_rect_to_monitor(xcb_rectangle_t client_rect,
+                                             xcb_rectangle_t monitor_rect);
 void client_set_focused(const struct natwm_state *state, struct client *client);
 void client_set_unfocused(const struct natwm_state *state,
                           struct client *client);

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -13,9 +13,8 @@
 #include "event.h"
 #include "randr-event.h"
 
-static enum natwm_error
-event_handle_map_request(const struct natwm_state *state,
-                         xcb_map_request_event_t *event)
+static enum natwm_error event_handle_map_request(struct natwm_state *state,
+                                                 xcb_map_request_event_t *event)
 {
         xcb_window_t window = event->window;
         struct client *client = client_register_window(state, window);
@@ -27,7 +26,7 @@ event_handle_map_request(const struct natwm_state *state,
         return NO_ERROR;
 }
 
-enum natwm_error event_handle(const struct natwm_state *state,
+enum natwm_error event_handle(struct natwm_state *state,
                               xcb_generic_event_t *event)
 {
         enum natwm_error err = GENERIC_ERROR;

--- a/src/core/events/event.h
+++ b/src/core/events/event.h
@@ -7,5 +7,5 @@
 #include <common/error.h>
 #include <core/state.h>
 
-enum natwm_error event_handle(const struct natwm_state *state,
+enum natwm_error event_handle(struct natwm_state *state,
                               xcb_generic_event_t *event);

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -133,6 +133,12 @@ void ewmh_init(const struct natwm_state *state)
                                         (uint32_t)NATWM_WORKSPACE_COUNT);
 }
 
+void ewmh_update_active_window(const struct natwm_state *state,
+                               xcb_window_t window)
+{
+        xcb_ewmh_set_active_window(state->ewmh, state->screen_num, window);
+}
+
 void ewmh_update_desktop_viewport(const struct natwm_state *state,
                                   const struct monitor_list *list)
 {

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -10,6 +10,8 @@
 
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
+void ewmh_update_active_window(const struct natwm_state *state,
+                               xcb_window_t window);
 void ewmh_update_desktop_viewport(const struct natwm_state *state,
                                   const struct monitor_list *list);
 void ewmh_update_desktop_names(const struct natwm_state *state,

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -305,6 +305,7 @@ monitor_list_get_workspace_monitor(const struct monitor_list *monitor_list,
                         continue;
                 }
 
+                // TODO: Not sure if matching strings is the best way to do this
                 if (strcmp(monitor->workspace->name, workspace->name) == 0) {
                         return monitor;
                 }

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -33,6 +33,26 @@ struct natwm_state *natwm_state_create(void)
         return state;
 }
 
+void natwm_state_lock(struct natwm_state *state)
+{
+        pthread_mutex_lock(&state->mutex);
+}
+
+void natwm_state_unlock(struct natwm_state *state)
+{
+        pthread_mutex_unlock(&state->mutex);
+}
+
+void natwm_state_update_config(struct natwm_state *state,
+                               const struct map *new_config)
+{
+        natwm_state_lock(state);
+
+        state->config = new_config;
+
+        natwm_state_unlock(state);
+}
+
 void natwm_state_destroy(struct natwm_state *state)
 {
         if (state == NULL) {
@@ -62,14 +82,4 @@ void natwm_state_destroy(struct natwm_state *state)
         pthread_mutex_destroy(&state->mutex);
 
         free(state);
-}
-
-void natwm_state_update_config(struct natwm_state *state,
-                               const struct map *new_config)
-{
-        pthread_mutex_lock(&state->mutex);
-
-        state->config = new_config;
-
-        pthread_mutex_unlock(&state->mutex);
 }

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -28,6 +28,8 @@ struct natwm_state {
 };
 
 struct natwm_state *natwm_state_create(void);
-void natwm_state_destroy(struct natwm_state *state);
+void natwm_state_lock(struct natwm_state *state);
+void natwm_state_unlock(struct natwm_state *state);
 void natwm_state_update_config(struct natwm_state *state,
                                const struct map *new_config);
+void natwm_state_destroy(struct natwm_state *state);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -33,6 +33,8 @@ struct workspace_list *workspace_list_create(size_t count);
 struct workspace *workspace_create(const char *tag_name);
 enum natwm_error workspace_list_init(const struct natwm_state *state,
                                      struct workspace_list **result);
-struct workspace *workspace_list_get_focused(struct workspace_list *list);
+enum natwm_error workspace_add_client(struct natwm_state *state,
+                                      struct client *client);
+struct workspace *workspace_list_get_focused(const struct workspace_list *list);
 void workspace_list_destroy(struct workspace_list *workspace_list);
 void workspace_destroy(struct workspace *workspace);


### PR DESCRIPTION
Implement more scalable way of mapping clients to workspaces. The hope is that this approach will be used almost entirely when handling workspace switching.

- Store the client on the workspace
- Update the theme to handle focus/unfocus
- Clamp the client to the bounds of the monitor it will reside on
- Add another supported ewmh root hint (active_window)