### PR TITLE
Feature/set up client window

### DIFF
--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -37,3 +37,5 @@
 
 #define WINDOW_BORDER_COLOR_CONFIG_STRING "window.border_color"
 #define WINDOW_BORDER_WIDTH_CONFIG_STRING "window.border_width"
+
+#define FRAME_CLASS_NAME "natwm_frame\0NATWM_FRAME"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(core
         pthread
         xcb
         xcb-ewmh
+        xcb-icccm
         xcb-randr
         xcb-xinerama
 )

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -177,7 +177,7 @@ struct client *client_register_window(struct natwm_state *state,
 
         xcb_change_save_set(state->xcb, XCB_SET_MODE_INSERT, client->window);
 
-        workspace_add_client(state, client);
+        workspace_add_client(state, focused_workspace->index, client);
 
         if (focused_workspace->is_visible) {
                 xcb_map_window(state->xcb, client->frame);

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -32,8 +32,8 @@ struct client_theme {
 
 struct client {
         // The parent which contains the window decorations
-        xcb_window_t parent;
-        xcb_window_t child;
+        xcb_window_t frame;
+        xcb_window_t window;
         xcb_rectangle_t rect;
         enum client_state state;
 };

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -19,6 +19,13 @@ enum client_state {
         CLIENT_STICKY,
 };
 
+enum client_hints {
+        FRAME_EXTENTS = 1U << 0U,
+        WM_ALLOWED_ACTIONS = 1U << 1U,
+        WM_DESKTOP = 1U << 2U,
+        CLIENT_HINTS_ALL = FRAME_EXTENTS | WM_ALLOWED_ACTIONS | WM_DESKTOP,
+};
+
 /**
  * This is the global theme for all clients.
  *
@@ -43,9 +50,17 @@ struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
 xcb_rectangle_t client_clamp_rect_to_monitor(xcb_rectangle_t client_rect,
                                              xcb_rectangle_t monitor_rect);
+uint16_t client_get_active_border_width(const struct client_theme *theme,
+                                        const struct client *client);
+struct color_value *
+client_get_active_border_color(const struct client_theme *theme,
+                               const struct client *client);
 void client_set_focused(const struct natwm_state *state, struct client *client);
 void client_set_unfocused(const struct natwm_state *state,
                           struct client *client);
+enum natwm_error client_update_hints(const struct natwm_state *state,
+                                     const struct client *client,
+                                     enum client_hints hints);
 
 enum natwm_error client_theme_create(const struct map *config_map,
                                      struct client_theme **result);

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -83,8 +83,6 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_MOVERESIZE_WINDOW,
                 state->ewmh->_NET_REQUEST_FRAME_EXTENTS,
                 // Application window properties
-                state->ewmh->_NET_WM_NAME,
-                state->ewmh->_NET_WM_VISIBLE_NAME,
                 state->ewmh->_NET_WM_DESKTOP,
                 state->ewmh->_NET_WM_WINDOW_TYPE,
                 state->ewmh->_NET_WM_STATE,
@@ -198,6 +196,17 @@ void ewmh_update_current_desktop(const struct natwm_state *state,
 
         xcb_ewmh_set_current_desktop(
                 state->ewmh, state->screen_num, (uint32_t)current_index);
+}
+
+void ewmh_update_frame_extents(const struct natwm_state *state,
+                               xcb_window_t window, uint32_t border_width)
+{
+        xcb_ewmh_set_frame_extents(state->ewmh,
+                                   window,
+                                   border_width,
+                                   border_width,
+                                   border_width,
+                                   border_width);
 }
 
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection)

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -198,8 +198,9 @@ void ewmh_update_current_desktop(const struct natwm_state *state,
                 state->ewmh, state->screen_num, (uint32_t)current_index);
 }
 
-void ewmh_update_frame_extents(const struct natwm_state *state,
-                               xcb_window_t window, uint32_t border_width)
+void ewmh_update_window_frame_extents(const struct natwm_state *state,
+                                      xcb_window_t window,
+                                      uint32_t border_width)
 {
         xcb_ewmh_set_frame_extents(state->ewmh,
                                    window,
@@ -207,6 +208,12 @@ void ewmh_update_frame_extents(const struct natwm_state *state,
                                    border_width,
                                    border_width,
                                    border_width);
+}
+
+void ewmh_update_window_desktop(const struct natwm_state *state,
+                                xcb_window_t window, size_t index)
+{
+        xcb_ewmh_set_wm_desktop(state->ewmh, window, (uint32_t)index);
 }
 
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection)

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -18,4 +18,6 @@ void ewmh_update_desktop_names(const struct natwm_state *state,
                                const struct workspace_list *list);
 void ewmh_update_current_desktop(const struct natwm_state *state,
                                  size_t current_index);
+void ewmh_update_frame_extents(const struct natwm_state *state,
+                               xcb_window_t window, uint32_t border_width);
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection);

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -18,6 +18,9 @@ void ewmh_update_desktop_names(const struct natwm_state *state,
                                const struct workspace_list *list);
 void ewmh_update_current_desktop(const struct natwm_state *state,
                                  size_t current_index);
-void ewmh_update_frame_extents(const struct natwm_state *state,
-                               xcb_window_t window, uint32_t border_width);
+void ewmh_update_window_frame_extents(const struct natwm_state *state,
+                                      xcb_window_t window,
+                                      uint32_t border_width);
+void ewmh_update_window_desktop(const struct natwm_state *state,
+                                xcb_window_t window, size_t index);
 void ewmh_destroy(xcb_ewmh_connection_t *ewmh_connection);

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -257,9 +257,7 @@ void workspace_list_destroy(struct workspace_list *workspace_list)
                 client_theme_destroy(workspace_list->theme);
         }
 
-        if (workspace_list->client_map->bucket_count > 0) {
-                map_destroy(workspace_list->client_map);
-        }
+        map_destroy(workspace_list->client_map);
 
         for (size_t i = 0; i < workspace_list->count; ++i) {
                 if (workspace_list->workspaces[i] != NULL) {

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -211,7 +211,7 @@ enum natwm_error workspace_add_client(struct natwm_state *state, size_t index,
         }
 
         // Cache which workspace this client is currenty active on
-        map_insert(list->client_map, &client->window, &index);
+        map_insert(list->client_map, &client->window, &workspace->index);
 
         workspace->active_client = client;
 
@@ -236,6 +236,11 @@ workspace_list_find_client_workspace(const struct workspace_list *list,
                                      const struct client *client)
 {
         struct map_entry *entry = map_get(list->client_map, &client->window);
+
+        if (entry == NULL) {
+                return NULL;
+        }
+
         size_t index = *(size_t *)entry->value;
 
         return list->workspaces[index];

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -81,7 +81,7 @@ workspace_init(const struct config_array *workspace_names, size_t index)
         const char *name = DEFAULT_WORKSPACE_NAMES[index];
 
         if (workspace_names == NULL || index >= workspace_names->length) {
-                return workspace_create(name, index);
+                goto create_default_named_workspace;
         }
 
         const struct config_value *name_value = workspace_names->values[index];
@@ -90,7 +90,7 @@ workspace_init(const struct config_array *workspace_names, size_t index)
                 LOG_WARNING(
                         natwm_logger, "Ignoring invalid workspace name", name);
 
-                return workspace_create(name, index);
+                goto create_default_named_workspace;
         }
 
         if (strlen(name_value->data.string) > NATWM_WORKSPACE_NAME_MAX_LEN) {
@@ -100,10 +100,15 @@ workspace_init(const struct config_array *workspace_names, size_t index)
                         name_value->data.string,
                         NATWM_WORKSPACE_NAME_MAX_LEN);
 
-                return workspace_create(name, index);
+                goto create_default_named_workspace;
         }
 
         return workspace_create(name_value->data.string, index);
+
+create_default_named_workspace:
+        // We couldn't find a valid user specified workspace name - fall back
+        // to using one from DEFAULT_WORKSPACE_NAMES
+        return workspace_create(name, index);
 }
 
 struct workspace_list *workspace_list_create(size_t count)

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -134,6 +134,7 @@ struct workspace *workspace_create(const char *name)
         workspace->is_focused = false;
         workspace->is_floating = false;
         workspace->clients = stack_create();
+        workspace->active_client = NULL;
 
         if (workspace->clients == NULL) {
                 free(workspace);
@@ -202,7 +203,7 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
 
         natwm_state_unlock(state);
 
-        if (previous_client != NULL) {
+        if (previous_client) {
                 client_set_unfocused(state, previous_client);
         }
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -33,6 +33,13 @@ static void workspace_client_destroy_callback(void *data)
         client_destroy(client);
 }
 
+static size_t get_client_list_key_size(const void *window)
+{
+        UNUSED_FUNCTION_PARAM(window);
+
+        return sizeof(xcb_window_t *);
+}
+
 /**
  * On first load we should give each monitor a workspace. The ordering of the
  * monitors is based on the order we recieve information about them in the
@@ -74,7 +81,7 @@ workspace_init(const struct config_array *workspace_names, size_t index)
         const char *name = DEFAULT_WORKSPACE_NAMES[index];
 
         if (workspace_names == NULL || index >= workspace_names->length) {
-                return workspace_create(name);
+                return workspace_create(name, index);
         }
 
         const struct config_value *name_value = workspace_names->values[index];
@@ -83,7 +90,7 @@ workspace_init(const struct config_array *workspace_names, size_t index)
                 LOG_WARNING(
                         natwm_logger, "Ignoring invalid workspace name", name);
 
-                return workspace_create(name);
+                return workspace_create(name, index);
         }
 
         if (strlen(name_value->data.string) > NATWM_WORKSPACE_NAME_MAX_LEN) {
@@ -93,10 +100,10 @@ workspace_init(const struct config_array *workspace_names, size_t index)
                         name_value->data.string,
                         NATWM_WORKSPACE_NAME_MAX_LEN);
 
-                return workspace_create(name);
+                return workspace_create(name, index);
         }
 
-        return workspace_create(name_value->data.string);
+        return workspace_create(name_value->data.string, index);
 }
 
 struct workspace_list *workspace_list_create(size_t count)
@@ -110,6 +117,11 @@ struct workspace_list *workspace_list_create(size_t count)
 
         workspace_list->count = count;
         workspace_list->theme = NULL;
+        workspace_list->client_map = map_init();
+
+        map_set_key_size_function(workspace_list->client_map,
+                                  get_client_list_key_size);
+
         workspace_list->workspaces = calloc(count, sizeof(struct workspace *));
 
         if (workspace_list->workspaces == NULL) {
@@ -121,7 +133,7 @@ struct workspace_list *workspace_list_create(size_t count)
         return workspace_list;
 }
 
-struct workspace *workspace_create(const char *name)
+struct workspace *workspace_create(const char *name, size_t index)
 {
         struct workspace *workspace = malloc(sizeof(struct workspace));
 
@@ -130,9 +142,9 @@ struct workspace *workspace_create(const char *name)
         }
 
         workspace->name = name;
+        workspace->index = index;
         workspace->is_visible = false;
         workspace->is_focused = false;
-        workspace->is_floating = false;
         workspace->clients = stack_create();
         workspace->active_client = NULL;
 
@@ -183,28 +195,30 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
         return NO_ERROR;
 }
 
-enum natwm_error workspace_add_client(struct natwm_state *state,
+enum natwm_error workspace_add_client(struct natwm_state *state, size_t index,
                                       struct client *client)
 {
         struct workspace_list *list = state->workspace_list;
-        struct workspace *focused_workspace = workspace_list_get_focused(list);
-        struct client *previous_client = focused_workspace->active_client;
+        struct workspace *workspace = list->workspaces[index];
+        struct client *previous_focused_client = workspace->active_client;
         enum natwm_error err = GENERIC_ERROR;
 
         // We will be modifying the state - need to lock until done
         natwm_state_lock(state);
 
-        if ((err = stack_push(focused_workspace->clients, client))
-            != NO_ERROR) {
+        if ((err = stack_push(workspace->clients, client)) != NO_ERROR) {
                 return err;
         }
 
-        focused_workspace->active_client = client;
+        // Cache which workspace this client is currenty active on
+        map_insert(list->client_map, &client->window, &index);
+
+        workspace->active_client = client;
 
         natwm_state_unlock(state);
 
-        if (previous_client) {
-                client_set_unfocused(state, previous_client);
+        if (previous_focused_client) {
+                client_set_unfocused(state, previous_focused_client);
         }
 
         client_set_focused(state, client);
@@ -217,10 +231,24 @@ struct workspace *workspace_list_get_focused(const struct workspace_list *list)
         return list->workspaces[list->active_index];
 }
 
+struct workspace *
+workspace_list_find_client_workspace(const struct workspace_list *list,
+                                     const struct client *client)
+{
+        struct map_entry *entry = map_get(list->client_map, &client->window);
+        size_t index = *(size_t *)entry->value;
+
+        return list->workspaces[index];
+}
+
 void workspace_list_destroy(struct workspace_list *workspace_list)
 {
         if (workspace_list->theme != NULL) {
                 client_theme_destroy(workspace_list->theme);
+        }
+
+        if (workspace_list->client_map->bucket_count > 0) {
+                map_destroy(workspace_list->client_map);
         }
 
         for (size_t i = 0; i < workspace_list->count; ++i) {

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -8,6 +8,7 @@
 #include <xcb/xcb.h>
 
 #include <common/error.h>
+#include <common/map.h>
 #include <common/stack.h>
 
 #include "client.h"
@@ -17,24 +18,28 @@ struct workspace_list {
         size_t count;
         size_t active_index;
         struct client_theme *theme;
+        struct map *client_map;
         struct workspace **workspaces;
 };
 
 struct workspace {
         const char *name;
+        size_t index;
         bool is_visible;
         bool is_focused;
-        bool is_floating;
         struct stack *clients;
         struct client *active_client;
 };
 
 struct workspace_list *workspace_list_create(size_t count);
-struct workspace *workspace_create(const char *tag_name);
+struct workspace *workspace_create(const char *tag_name, size_t index);
 enum natwm_error workspace_list_init(const struct natwm_state *state,
                                      struct workspace_list **result);
-enum natwm_error workspace_add_client(struct natwm_state *state,
+enum natwm_error workspace_add_client(struct natwm_state *state, size_t index,
                                       struct client *client);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);
+struct workspace *
+workspace_list_find_client_workspace(const struct workspace_list *list,
+                                     const struct client *client);
 void workspace_list_destroy(struct workspace_list *workspace_list);
 void workspace_destroy(struct workspace *workspace);


### PR DESCRIPTION
Work on implementing more EWMH hints for added windows. The following are now supported:

- `_NET_WM_DESKTOP`
- `_NET_FRAME_EXTENTS`

Additionally support for adding `_NET_WM_ALLOWED_ACTIONS` is planned, but will be added as actions are supported.

Additional hints will be added as needed, and this PR makes supporting them and updating them easier.

Other items addressed in this PR:

- We are now caching window->workspace index mapping. This allows for quicker lookup of current workspace. And made supporting the setting/updating of `_NET_WM_DESKTOP` very easy/efficient.

- We are now properly setting `WM_CLASS` on the frame window

- Added getters for getting theme items based on the state of the window