### PR TITLE
Feature/stack peek

### DIFF
--- a/src/common/stack.c
+++ b/src/common/stack.c
@@ -34,7 +34,7 @@ struct stack_item *stack_item_create(void *data)
         return item;
 }
 
-bool stack_has_item(struct stack *stack)
+bool stack_has_item(const struct stack *stack)
 {
         return stack->head != NULL;
 }
@@ -108,6 +108,29 @@ struct stack_item *stack_pop(struct stack *stack)
         --stack->length;
 
         return item;
+}
+
+const struct stack_item *stack_peek_n(const struct stack *stack, size_t index)
+{
+        if (!stack_has_item(stack) || stack->length < index) {
+                return NULL;
+        }
+
+        struct stack_item *curr = stack->head;
+        size_t i = 0;
+
+        while (i <= index && curr != NULL && curr->next != NULL) {
+                curr = curr->next;
+
+                ++i;
+        }
+
+        return curr;
+}
+
+const struct stack_item *stack_peek(const struct stack *stack)
+{
+        return stack_peek_n(stack, 0);
 }
 
 struct stack_item *stack_dequeue(struct stack *stack)

--- a/src/common/stack.c
+++ b/src/common/stack.c
@@ -119,7 +119,7 @@ const struct stack_item *stack_peek_n(const struct stack *stack, size_t index)
         struct stack_item *curr = stack->head;
         size_t i = 0;
 
-        while (i <= index && curr != NULL && curr->next != NULL) {
+        while (i < index && curr != NULL && curr->next != NULL) {
                 curr = curr->next;
 
                 ++i;
@@ -173,6 +173,8 @@ void stack_item_destroy_callback(struct stack_item *item,
         }
 
         free_function((void *)item->data);
+
+        stack_item_destroy(item);
 }
 
 void stack_destroy(struct stack *stack)

--- a/src/common/stack.h
+++ b/src/common/stack.h
@@ -24,7 +24,7 @@ struct stack {
 struct stack *stack_create(void);
 struct stack_item *stack_item_create(void *data);
 
-bool stack_has_item(struct stack *stack);
+bool stack_has_item(const struct stack *stack);
 
 void stack_push_item(struct stack *stack, struct stack_item *item);
 enum natwm_error stack_push(struct stack *stack, void *data);
@@ -32,6 +32,8 @@ void stack_enqueue_item(struct stack *stack, struct stack_item *item);
 enum natwm_error stack_enqueue(struct stack *stack, void *data);
 
 struct stack_item *stack_pop(struct stack *stack);
+const struct stack_item *stack_peek(const struct stack *stack);
+const struct stack_item *stack_peek_n(const struct stack *stack, size_t index);
 struct stack_item *stack_dequeue(struct stack *state);
 
 void stack_item_destroy(struct stack_item *item);

--- a/src/test/test_stack.c
+++ b/src/test/test_stack.c
@@ -283,6 +283,99 @@ static void test_stack_pop_empty(void **state)
         assert_false(stack_has_item(stack));
 }
 
+static void test_stack_peek(void **state)
+{
+        struct stack *stack = *(struct stack **)state;
+        size_t expected_data = 14;
+
+        assert_int_equal(NO_ERROR, stack_push(stack, &expected_data));
+        assert_true(stack_has_item(stack));
+
+        const struct stack_item *stack_item = stack_peek(stack);
+
+        assert_non_null(stack_item);
+        assert_int_equal(expected_data, *(size_t *)stack_item->data);
+        assert_true(stack_has_item(stack));
+        assert_int_equal(1, stack->length);
+}
+
+static void test_stack_peek_multiple(void **state)
+{
+        struct stack *stack = *(struct stack **)state;
+        size_t first = 123;
+        size_t expected_data = 123;
+
+        assert_int_equal(NO_ERROR, stack_push(stack, &first));
+        assert_true(stack_has_item(stack));
+        assert_int_equal(NO_ERROR, stack_push(stack, &expected_data));
+        assert_int_equal(2, stack->length);
+
+        const struct stack_item *stack_item = stack_peek(stack);
+
+        assert_non_null(stack_item);
+        assert_int_equal(expected_data, *(size_t *)stack_item->data);
+        assert_true(stack_has_item(stack));
+        assert_int_equal(2, stack->length);
+}
+
+static void test_stack_peek_empty(void **state)
+{
+        struct stack *stack = *(struct stack **)state;
+        size_t data = 14;
+
+        assert_false(stack_has_item(stack));
+        assert_null(stack_peek(stack));
+        assert_int_equal(NO_ERROR, stack_push(stack, &data));
+        assert_true(stack_has_item(stack));
+        assert_int_equal(1, stack->length);
+
+        struct stack_item *stack_item = stack_pop(stack);
+
+        assert_non_null(stack_item);
+        assert_false(stack_has_item(stack));
+        assert_null(stack_peek(stack));
+
+        stack_item_destroy(stack_item);
+}
+
+static void test_stack_peek_n(void **state)
+{
+        struct stack *stack = *(struct stack **)state;
+        size_t expected_data_first = 123;
+        size_t expected_data_second = 456;
+        size_t expected_data_third = 456;
+
+        assert_false(stack_has_item(stack));
+        assert_int_equal(NO_ERROR, stack_push(stack, &expected_data_first));
+        assert_int_equal(NO_ERROR, stack_push(stack, &expected_data_second));
+        assert_int_equal(NO_ERROR, stack_push(stack, &expected_data_third));
+        assert_true(stack_has_item(stack));
+        assert_int_equal(3, stack->length);
+
+        const struct stack_item *stack_item_zero = stack_peek_n(stack, 0);
+        const struct stack_item *stack_item_one = stack_peek_n(stack, 1);
+        const struct stack_item *stack_item_two = stack_peek_n(stack, 2);
+
+        assert_non_null(stack_item_zero);
+        assert_non_null(stack_item_one);
+        assert_non_null(stack_item_two);
+        assert_true(stack_has_item(stack));
+        assert_int_equal(3, stack->length);
+        assert_int_equal(expected_data_third, *(size_t *)stack_item_zero->data);
+        assert_int_equal(expected_data_second, *(size_t *)stack_item_one->data);
+        assert_int_equal(expected_data_first, *(size_t *)stack_item_two->data);
+}
+
+static void test_stack_peek_n_not_found(void **state)
+{
+        struct stack *stack = *(struct stack **)state;
+
+        assert_false(stack_has_item(stack));
+        assert_null(stack_peek_n(stack, 0));
+        assert_null(stack_peek_n(stack, 5));
+        assert_null(stack_peek_n(stack, 10));
+}
+
 static void test_stack_dequeue(void **state)
 {
         struct stack *stack = *(struct stack **)state;
@@ -431,6 +524,16 @@ int main(void)
                         test_stack_pop_multiple, test_setup, test_teardown),
                 cmocka_unit_test_setup_teardown(
                         test_stack_pop_empty, test_setup, test_teardown),
+                cmocka_unit_test_setup_teardown(
+                        test_stack_peek, test_setup, test_teardown),
+                cmocka_unit_test_setup_teardown(
+                        test_stack_peek_multiple, test_setup, test_teardown),
+                cmocka_unit_test_setup_teardown(
+                        test_stack_peek_empty, test_setup, test_teardown),
+                cmocka_unit_test_setup_teardown(
+                        test_stack_peek_n, test_setup, test_teardown),
+                cmocka_unit_test_setup_teardown(
+                        test_stack_peek_n_not_found, test_setup, test_teardown),
                 cmocka_unit_test_setup_teardown(
                         test_stack_dequeue, test_setup, test_teardown),
                 cmocka_unit_test_setup_teardown(


### PR DESCRIPTION
Add the ability to peek into the stack without removing an item.

- Const correctness fix for `stack_has_item`
- Adds `stack_peek` for peeking at the head
- Adds `stack_peek_n` for peeking at the nth item
- Adds tests for the above
- Fixes memory leak issue found in `stack_item_destroy_callback`