### PR TITLE
Feature/handle unmap notify event

### DIFF
--- a/src/common/stack.h
+++ b/src/common/stack.h
@@ -21,6 +21,10 @@ struct stack {
         struct stack_item *head;
 };
 
+#define STACK_FOR_EACH(stack, item)                                            \
+        for (struct stack_item * (item) = (stack)->head; (item) != NULL;       \
+             (item) = (item)->next)
+
 struct stack *stack_create(void);
 struct stack_item *stack_item_create(void *data);
 

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -45,10 +45,14 @@ static xcb_window_t create_frame_window(const struct natwm_state *state,
 {
         // Create the parent which will contain the window decorations
         xcb_window_t frame = xcb_generate_id(state->xcb);
-        uint32_t mask = XCB_CW_BORDER_PIXEL | XCB_CW_SAVE_UNDER;
+        uint32_t mask
+                = XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP;
         uint32_t values[] = {
                 theme->color->unfocused->color_value,
-                1,
+                XCB_EVENT_MASK_STRUCTURE_NOTIFY
+                        | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY
+                        | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT,
+                state->screen->default_colormap,
         };
 
         xcb_create_window(state->xcb,

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -14,10 +14,10 @@
 #include "state.h"
 
 enum client_state {
-        CLIENT_URGENT = 1U << 0U,
-        CLIENT_STICKY = 1U << 1U,
-        CLIENT_HIDDEN = 1U << 2U,
-        CLIENT_NORMAL = 1U << 3U,
+        CLIENT_URGENT,
+        CLIENT_STICKY,
+        CLIENT_HIDDEN,
+        CLIENT_NORMAL,
 };
 
 enum client_hints {

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <xcb/xcb.h>
 
 #include <common/error.h>
@@ -13,10 +14,10 @@
 #include "state.h"
 
 enum client_state {
-        CLIENT_FOCUSED,
-        CLIENT_UNFOCUSED,
-        CLIENT_URGENT,
-        CLIENT_STICKY,
+        CLIENT_URGENT = 1U << 0U,
+        CLIENT_STICKY = 1U << 1U,
+        CLIENT_HIDDEN = 1U << 2U,
+        CLIENT_NORMAL = 1U << 3U,
 };
 
 enum client_hints {
@@ -42,6 +43,7 @@ struct client {
         xcb_window_t frame;
         xcb_window_t window;
         xcb_rectangle_t rect;
+        bool is_focused;
         enum client_state state;
 };
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -50,6 +50,8 @@ struct client {
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect);
 struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
+enum natwm_error client_unmap_window(struct natwm_state *state,
+                                     xcb_window_t window);
 xcb_rectangle_t client_clamp_rect_to_monitor(xcb_rectangle_t client_rect,
                                              xcb_rectangle_t monitor_rect);
 uint16_t client_get_active_border_width(const struct client_theme *theme,

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -26,6 +26,18 @@ static enum natwm_error event_handle_map_request(struct natwm_state *state,
         return NO_ERROR;
 }
 
+static enum natwm_error
+event_handle_unmap_notify(struct natwm_state *state,
+                          xcb_unmap_notify_event_t *event)
+{
+        UNUSED_FUNCTION_PARAM(state);
+        UNUSED_FUNCTION_PARAM(event);
+
+        LOG_INFO(natwm_logger, "Handle UNMAP notify");
+
+        return NO_ERROR;
+}
+
 enum natwm_error event_handle(struct natwm_state *state,
                               xcb_generic_event_t *event)
 {
@@ -36,6 +48,10 @@ enum natwm_error event_handle(struct natwm_state *state,
         case XCB_MAP_REQUEST:
                 err = event_handle_map_request(
                         state, (xcb_map_request_event_t *)event);
+                break;
+        case XCB_UNMAP_NOTIFY:
+                err = event_handle_unmap_notify(
+                        state, (xcb_unmap_notify_event_t *)event);
                 break;
         }
 

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -30,10 +30,12 @@ static enum natwm_error
 event_handle_unmap_notify(struct natwm_state *state,
                           xcb_unmap_notify_event_t *event)
 {
-        UNUSED_FUNCTION_PARAM(state);
-        UNUSED_FUNCTION_PARAM(event);
+        xcb_window_t window = event->window;
+        enum natwm_error err = client_unmap_window(state, window);
 
-        LOG_INFO(natwm_logger, "Handle UNMAP notify");
+        if (err != NO_ERROR) {
+                return err;
+        }
 
         return NO_ERROR;
 }
@@ -53,10 +55,6 @@ enum natwm_error event_handle(struct natwm_state *state,
                 err = event_handle_unmap_notify(
                         state, (xcb_unmap_notify_event_t *)event);
                 break;
-        }
-
-        if (err != NO_ERROR) {
-                return err;
         }
 
         // If we are using the randr extension then we support additional events

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -40,6 +40,16 @@ static size_t get_client_list_key_size(const void *window)
         return sizeof(xcb_window_t *);
 }
 
+static bool compare_windows(const void *one, const void *two, size_t key_size)
+{
+        UNUSED_FUNCTION_PARAM(key_size);
+
+        xcb_window_t window_one = *(xcb_window_t *)one;
+        xcb_window_t window_two = *(xcb_window_t *)two;
+
+        return window_one == window_two;
+}
+
 /**
  * On first load we should give each monitor a workspace. The ordering of the
  * monitors is based on the order we recieve information about them in the
@@ -124,6 +134,8 @@ struct workspace_list *workspace_list_create(size_t count)
         workspace_list->theme = NULL;
         workspace_list->client_map = map_init();
 
+        map_set_key_compare_function(workspace_list->client_map,
+                                     compare_windows);
         map_set_key_size_function(workspace_list->client_map,
                                   get_client_list_key_size);
 

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -35,11 +35,22 @@ struct workspace_list *workspace_list_create(size_t count);
 struct workspace *workspace_create(const char *tag_name, size_t index);
 enum natwm_error workspace_list_init(const struct natwm_state *state,
                                      struct workspace_list **result);
-enum natwm_error workspace_add_client(struct natwm_state *state, size_t index,
+enum natwm_error workspace_add_client(struct natwm_state *state,
+                                      struct workspace *workspace,
                                       struct client *client);
+struct client *workspace_find_window_client(const struct workspace *workspace,
+                                            xcb_window_t window);
+enum natwm_error workspace_update_focused(const struct natwm_state *state,
+                                          struct workspace *list);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);
 struct workspace *
 workspace_list_find_client_workspace(const struct workspace_list *list,
                                      const struct client *client);
+struct workspace *
+workspace_list_find_window_workspace(const struct workspace_list *list,
+                                     xcb_window_t window);
+struct client *
+workspace_list_find_window_client(const struct workspace_list *list,
+                                  xcb_window_t window);
 void workspace_list_destroy(struct workspace_list *workspace_list);
 void workspace_destroy(struct workspace *workspace);

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -164,6 +164,8 @@ static void *start_wm_events_thread(void *passed_state)
 
                         free(event);
 
+                        xcb_flush(state->xcb);
+
                         continue;
                 }
 

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -139,6 +139,8 @@ static int root_window_subscribe(const struct natwm_state *state)
                 state->xcb, state->screen->root, XCB_CW_EVENT_MASK, &root_mask);
         xcb_generic_error_t *error = xcb_request_check(state->xcb, cookie);
 
+        xcb_flush(state->xcb);
+
         if (error != NULL) {
                 // We will fail if there is already a window manager present
                 free(error);


### PR DESCRIPTION
A pretty simple event which required a lot of effort in other areas of the wm.

- Required updating the stack to allow finding the window passed with the event #66 
- Required updating the stack mode of windows
- Required updating the client focus code
- Actually handling the unmapping logic