### PR TITLE
Feature/improve window clamp

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -79,7 +79,8 @@ else
 fi
 
 export DISPLAY=:14
-xterm &
+feh --bg-center ~/Documents/wallpapers/pixel.jpg &
+urxvt &
 $($BIN)
 
 killall $XEPHYR

--- a/run.sh
+++ b/run.sh
@@ -79,7 +79,6 @@ else
 fi
 
 export DISPLAY=:14
-feh --bg-center ~/Documents/wallpapers/pixel.jpg &
 urxvt &
 $($BIN)
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <xcb/xcb.h>
+#include <xcb/xcb_icccm.h>
 
 #include <common/error.h>
 #include <common/map.h>
@@ -43,19 +44,21 @@ struct client {
         xcb_window_t frame;
         xcb_window_t window;
         xcb_rectangle_t rect;
+        xcb_size_hints_t size_hints;
         bool is_focused;
         enum client_state state;
 };
 
-struct client *client_create(xcb_window_t window, xcb_rectangle_t rect);
+struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
+                             xcb_size_hints_t hints);
 enum natwm_error client_destroy_window(struct natwm_state *state,
                                        xcb_window_t window);
 struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
-xcb_rectangle_t client_clamp_rect_to_monitor(xcb_rectangle_t client_rect,
-                                             xcb_rectangle_t monitor_rect);
+xcb_rectangle_t client_initialize_rect(struct client *client,
+                                       xcb_rectangle_t monitor_rect);
 uint16_t client_get_active_border_width(const struct client_theme *theme,
                                         const struct client *client);
 struct color_value *

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -58,6 +58,7 @@ struct client *client_register_window(struct natwm_state *state,
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
 xcb_rectangle_t client_initialize_rect(struct client *client,
+                                       uint16_t border_width,
                                        xcb_rectangle_t monitor_rect);
 uint16_t client_get_active_border_width(const struct client_theme *theme,
                                         const struct client *client);

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -128,6 +128,12 @@ struct workspace_list *workspace_list_create(size_t count)
         workspace_list->theme = NULL;
         workspace_list->client_map = map_init();
 
+        if (workspace_list->client_map == NULL) {
+                free(workspace_list);
+
+                return NULL;
+        }
+
         map_set_key_compare_function(workspace_list->client_map,
                                      compare_windows);
         map_set_key_size_function(workspace_list->client_map,
@@ -136,6 +142,8 @@ struct workspace_list *workspace_list_create(size_t count)
         workspace_list->workspaces = calloc(count, sizeof(struct workspace *));
 
         if (workspace_list->workspaces == NULL) {
+                map_destroy(workspace_list->client_map);
+
                 free(workspace_list);
 
                 return NULL;
@@ -287,6 +295,9 @@ enum natwm_error workspace_reset_focus(struct natwm_state *state,
                 return NO_ERROR;
         }
 
+        // There are no more clients on this workspace
+        workspace->active_client = NULL;
+
         return NOT_FOUND_ERROR;
 }
 
@@ -295,7 +306,6 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
                                       struct client *client)
 {
         struct workspace_list *list = state->workspace_list;
-        struct client *previous_focused_client = workspace->active_client;
 
         // We will be modifying the state - need to lock until done
         natwm_state_lock(state);
@@ -309,13 +319,14 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
         // Cache which workspace this client is currenty active on
         map_insert(list->client_map, &client->window, &workspace->index);
 
+        // Update active_client
+        if (workspace->active_client) {
+                client_set_unfocused(state, workspace->active_client);
+        }
+
         workspace->active_client = client;
 
         natwm_state_unlock(state);
-
-        if (previous_focused_client) {
-                client_set_unfocused(state, previous_focused_client);
-        }
 
         client_set_focused(state, client);
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -146,9 +146,7 @@ struct workspace_list *workspace_list_create(size_t count)
 
 static struct client *get_client_from_client_node(struct node *client_node)
 {
-        struct client *client = (struct client *)client_node->data;
-
-        return client;
+        return (struct client *)client_node->data;
 }
 
 static struct node *get_client_node_from_client(struct list *client_list,
@@ -440,10 +438,10 @@ void workspace_destroy(const struct natwm_state *state,
                        struct workspace *workspace)
 {
         if (workspace->clients != NULL) {
-                LIST_FOR_EACH(workspace->clients, client_item)
+                LIST_FOR_EACH(workspace->clients, node)
                 {
                         struct client *client
-                                = (struct client *)client_item->data;
+                                = get_client_from_client_node(node);
 
                         xcb_destroy_window(state->xcb, client->frame);
 


### PR DESCRIPTION
Previously there was a very simple and incomplete implementation for clamping windows to the current monitor size. This didn't really handle anything and completely ignored window hints and theme updating.

This PR adds the following:

- Retrieve and account for ICCCM_SIZE_HINTS
- Initialize client rects by clamping them to the active monitor rect
- Account for monitor width/height/x/y values
- Properly handle theme updates by updating not only color but also border width
- When border width changes make sure to re-calculate window width