### PR TITLE
Feature/configure event

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -246,6 +246,18 @@ struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
         client->window = window;
         client->rect = rect;
         client->size_hints = hints;
+
+        // Initialize size_hints
+        if (!(client->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE)) {
+                client->size_hints->max_width = UINT16_MAX;
+                client->size_hints->max_height = UINT16_MAX;
+        }
+
+        if (!(client->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE)) {
+                client->size_hints->min_width = 0;
+                client->size_hints->min_height = 0;
+        }
+
         client->is_focused = false;
         client->state = CLIENT_NORMAL;
 
@@ -259,7 +271,7 @@ enum natwm_error client_configure_window(struct natwm_state *state,
                 state->workspace_list, event->window);
 
         if (workspace == NULL) {
-                // Event is not registered with us - just pass it along
+                // window is not registered with us - just pass it along
                 goto handle_not_registered;
         }
 
@@ -525,7 +537,7 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
         return NO_ERROR;
 }
 
-xcb_rectangle_t client_initialize_rect(struct client *client,
+xcb_rectangle_t client_initialize_rect(const struct client *client,
                                        uint16_t border_width,
                                        xcb_rectangle_t monitor_rect)
 {

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -68,7 +68,8 @@ static void configure_window(xcb_connection_t *connection,
                 return;
         }
 
-        xcb_configure_window(connection, event->window, mask, &values);
+        xcb_configure_window(
+                connection, event->window, mask, (uint32_t *)&values);
 }
 
 static enum natwm_error get_window_rect(xcb_connection_t *connection,

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -42,13 +42,13 @@ struct client_theme {
 struct client {
         xcb_window_t window;
         xcb_rectangle_t rect;
-        xcb_size_hints_t size_hints;
+        xcb_size_hints_t *size_hints;
         bool is_focused;
         enum client_state state;
 };
 
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
-                             xcb_size_hints_t hints);
+                             xcb_size_hints_t *hints);
 enum natwm_error client_configure_window(struct natwm_state *state,
                                          xcb_configure_request_event_t *event);
 enum natwm_error client_destroy_window(struct natwm_state *state,

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -57,7 +57,7 @@ struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
-xcb_rectangle_t client_initialize_rect(struct client *client,
+xcb_rectangle_t client_initialize_rect(const struct client *client,
                                        uint16_t border_width,
                                        xcb_rectangle_t monitor_rect);
 uint16_t client_get_active_border_width(const struct client_theme *theme,

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -49,6 +49,8 @@ struct client {
 
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
                              xcb_size_hints_t hints);
+enum natwm_error client_configure_window(struct natwm_state *state,
+                                         xcb_configure_request_event_t *event);
 enum natwm_error client_destroy_window(struct natwm_state *state,
                                        xcb_window_t window);
 struct client *client_register_window(struct natwm_state *state,

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -71,7 +71,7 @@ enum natwm_error event_handle(struct natwm_state *state,
         uint8_t type = (uint8_t)(event->response_type & ~0x80);
 
         switch (type) {
-        case XCB_CONFIGURE_NOTIFY:
+        case XCB_CONFIGURE_REQUEST:
                 err = event_handle_configure_request(
                         state, (xcb_configure_request_event_t *)event);
                 break;

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -15,6 +15,13 @@
 #include "randr-event.h"
 
 static enum natwm_error
+event_handle_configure_request(struct natwm_state *state,
+                               xcb_configure_request_event_t *event)
+{
+        return client_configure_window(state, event);
+}
+
+static enum natwm_error
 event_handle_destroy_notify(struct natwm_state *state,
                             xcb_destroy_notify_event_t *event)
 {
@@ -64,6 +71,10 @@ enum natwm_error event_handle(struct natwm_state *state,
         uint8_t type = (uint8_t)(event->response_type & ~0x80);
 
         switch (type) {
+        case XCB_CONFIGURE_NOTIFY:
+                err = event_handle_configure_request(
+                        state, (xcb_configure_request_event_t *)event);
+                break;
         case XCB_DESTROY_NOTIFY:
                 err = event_handle_destroy_notify(
                         state, (xcb_destroy_notify_event_t *)event);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -43,6 +43,12 @@ enum natwm_error workspace_remove_client(struct natwm_state *state,
                                          struct client *client);
 struct client *workspace_find_window_client(const struct workspace *workspace,
                                             xcb_window_t window);
+enum natwm_error workspace_focus_existing_client(struct natwm_state *state,
+                                                 struct workspace *workspace,
+                                                 struct client *client);
+enum natwm_error workspace_unfocus_existing_client(struct natwm_state *state,
+                                                   struct workspace *workspace,
+                                                   struct client *client);
 enum natwm_error workspace_reset_focus(struct natwm_state *state,
                                        struct workspace *workspace);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);


### PR DESCRIPTION
Respond to `XCB_CONFIGURE_REQUEST` events and correctly configure the passed window

Includes the following changes:

- More focus logic for workspaces
- Event handling implementation
- Avoid passing xcb_size_hints_t by value