### PR TITLE
Feature/click to focus

### DIFF
--- a/src/common/map.c
+++ b/src/common/map.c
@@ -50,7 +50,8 @@ static bool default_key_compare_function(const void *one, const void *two,
 // Given a map_entry determine if it holds valid data and is present
 static bool is_entry_present(const struct map_entry *entry)
 {
-        if (entry != NULL && entry->key != NULL) {
+        if (entry != NULL && entry->key != NULL
+            && entry->value != &EMPTY_ENTRY) {
                 return true;
         }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(core STATIC
     ewmh.h
     monitor.c
     monitor.h
+    mouse.c
+    mouse.h
     randr.c
     randr.h
     state.c

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -395,8 +395,6 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
                         state, workspace, client);
         }
 
-        LOG_INFO(natwm_logger, "Another button event");
-
         return NO_ERROR;
 }
 

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -11,6 +11,7 @@
 #include "client.h"
 #include "ewmh.h"
 #include "monitor.h"
+#include "mouse.h"
 #include "workspace.h"
 
 static void configure_window(xcb_connection_t *connection,
@@ -485,6 +486,9 @@ struct client *client_register_window(struct natwm_state *state,
 
         client_update_hints(state, client, CLIENT_HINTS_ALL);
 
+        // Listen for button events
+        mouse_client_listener(state, client);
+
         xcb_map_window(state->xcb, client->window);
 
         xcb_flush(state->xcb);
@@ -740,4 +744,6 @@ void client_destroy(struct client *client)
         free(client->size_hints);
 
         free(client);
+
+        client = NULL;
 }

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -49,14 +49,16 @@ struct client {
 
 struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
                              xcb_size_hints_t *hints);
-enum natwm_error client_configure_window(struct natwm_state *state,
-                                         xcb_configure_request_event_t *event);
-enum natwm_error client_destroy_window(struct natwm_state *state,
-                                       xcb_window_t window);
 struct client *client_register_window(struct natwm_state *state,
                                       xcb_window_t window);
+enum natwm_error client_handle_button_press(struct natwm_state *state,
+                                            xcb_button_press_event_t *event);
+enum natwm_error client_configure_window(struct natwm_state *state,
+                                         xcb_configure_request_event_t *event);
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
+enum natwm_error client_destroy_window(struct natwm_state *state,
+                                       xcb_window_t window);
 xcb_rectangle_t client_initialize_rect(const struct client *client,
                                        uint16_t border_width,
                                        xcb_rectangle_t monitor_rect);

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -10,9 +10,17 @@
 #include <core/client.h>
 #include <core/ewmh.h>
 #include <core/monitor.h>
+#include <core/mouse.h>
 
 #include "event.h"
 #include "randr-event.h"
+
+static enum natwm_error
+event_handle_button_press(struct natwm_state *state,
+                          xcb_button_press_event_t *event)
+{
+        return client_handle_button_press(state, event);
+}
 
 static enum natwm_error
 event_handle_configure_request(struct natwm_state *state,
@@ -72,7 +80,8 @@ enum natwm_error event_handle(struct natwm_state *state,
 
         switch (type) {
         case XCB_BUTTON_PRESS:
-                LOG_INFO(natwm_logger, "Button press event");
+                err = event_handle_button_press(
+                        state, (xcb_button_press_event_t *)event);
                 break;
         case XCB_CONFIGURE_REQUEST:
                 err = event_handle_configure_request(

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -71,6 +71,9 @@ enum natwm_error event_handle(struct natwm_state *state,
         uint8_t type = (uint8_t)(event->response_type & ~0x80);
 
         switch (type) {
+        case XCB_BUTTON_PRESS:
+                LOG_INFO(natwm_logger, "Button press event");
+                break;
         case XCB_CONFIGURE_REQUEST:
                 err = event_handle_configure_request(
                         state, (xcb_configure_request_event_t *)event);

--- a/src/core/mouse.c
+++ b/src/core/mouse.c
@@ -6,22 +6,32 @@
 
 #include "mouse.h"
 
-void mouse_client_listener(const struct natwm_state *state,
-                           const struct client *client)
+void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
+                             const struct mouse_binding *binding)
+{
+        xcb_grab_button(connection,
+                        binding->pass_event,
+                        window,
+                        binding->mask,
+                        binding->pointer_mode,
+                        binding->keyboard_mode,
+                        XCB_NONE,
+                        binding->cursor,
+                        binding->button,
+                        binding->modifiers);
+}
+
+// These are the mouse events which will persist for the life of the client.
+// The only mouse event which will not be initialized here is the "click to
+// focus" event which needs to be created or destroyed based on the client
+// focus
+void mouse_initialize_client_listeners(const struct natwm_state *state,
+                                       const struct client *client)
 {
         for (size_t i = 0; i < MOUSE_EVENTS_NUM; ++i) {
                 struct mouse_binding binding = mouse_events[i];
 
-                xcb_grab_button(state->xcb,
-                                binding.pass_event,
-                                client->window,
-                                binding.mask,
-                                binding.pointer_mode,
-                                binding.keyboard_mode,
-                                XCB_NONE,
-                                binding.cursor,
-                                binding.button,
-                                binding.modifiers);
+                mouse_event_grab_button(state->xcb, client->window, &binding);
         };
 
         xcb_flush(state->xcb);

--- a/src/core/mouse.c
+++ b/src/core/mouse.c
@@ -1,0 +1,28 @@
+// Copyright 2020 Chris Frank
+// Licensed under BSD-3-Clause
+// Refer to the license.txt file included in the root of the project
+
+#include <xcb/xcb.h>
+
+#include "mouse.h"
+
+void mouse_client_listener(const struct natwm_state *state,
+                           const struct client *client)
+{
+        for (size_t i = 0; i < MOUSE_EVENTS_NUM; ++i) {
+                struct mouse_binding binding = mouse_events[i];
+
+                xcb_grab_button(state->xcb,
+                                binding.pass_event,
+                                client->window,
+                                binding.mask,
+                                binding.pointer_mode,
+                                binding.keyboard_mode,
+                                XCB_NONE,
+                                binding.cursor,
+                                binding.button,
+                                binding.modifiers);
+        };
+
+        xcb_flush(state->xcb);
+}

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -12,6 +12,9 @@
 
 #define MOUSE_EVENTS_NUM 1
 
+#define DEFAULT_BUTTON_MASK                                                    \
+        XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE
+
 struct mouse_binding {
         uint8_t pass_event;
         uint16_t mask;
@@ -21,9 +24,6 @@ struct mouse_binding {
         uint8_t button;
         uint16_t modifiers;
 };
-
-static const uint16_t DEFAULT_BUTTON_MASK
-        = XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE;
 
 static const struct mouse_binding client_focus_event = {
         .pass_event = 1,

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -1,0 +1,51 @@
+// Copyright 2020 Chris Frank
+// Licensed under BSD-3-Clause
+// Refer to the license.txt file included in the root of the project
+
+#pragma once
+
+#include <stdint.h>
+#include <xcb/xproto.h>
+
+#include "client.h"
+#include "state.h"
+
+#define MOUSE_EVENTS_NUM 2
+
+struct mouse_binding {
+        uint8_t pass_event;
+        uint16_t mask;
+        uint8_t pointer_mode;
+        uint8_t keyboard_mode;
+        xcb_cursor_t cursor;
+        uint8_t button;
+        uint16_t modifiers;
+};
+
+static const uint16_t DEFAULT_BUTTON_MASK
+        = XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE;
+
+static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
+        // A simple single button press with no keyboard modifiers (sets focus)
+        {
+                .pass_event = 1,
+                .mask = DEFAULT_BUTTON_MASK,
+                .pointer_mode = XCB_GRAB_MODE_ASYNC,
+                .keyboard_mode = XCB_GRAB_MODE_ASYNC,
+                .cursor = XCB_NONE,
+                .button = XCB_BUTTON_INDEX_1,
+                .modifiers = XCB_NONE,
+        },
+        {
+                .pass_event = 0,
+                .mask = DEFAULT_BUTTON_MASK,
+                .pointer_mode = XCB_GRAB_MODE_ASYNC,
+                .keyboard_mode = XCB_GRAB_MODE_ASYNC,
+                .cursor = XCB_NONE,
+                .button = XCB_BUTTON_INDEX_1,
+                .modifiers = XCB_MOD_MASK_1,
+        },
+};
+
+void mouse_client_listener(const struct natwm_state *state,
+                           const struct client *client);

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -10,7 +10,7 @@
 #include "client.h"
 #include "state.h"
 
-#define MOUSE_EVENTS_NUM 2
+#define MOUSE_EVENTS_NUM 1
 
 struct mouse_binding {
         uint8_t pass_event;
@@ -25,17 +25,17 @@ struct mouse_binding {
 static const uint16_t DEFAULT_BUTTON_MASK
         = XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE;
 
+static const struct mouse_binding client_focus_event = {
+        .pass_event = 1,
+        .mask = DEFAULT_BUTTON_MASK,
+        .pointer_mode = XCB_GRAB_MODE_ASYNC,
+        .keyboard_mode = XCB_GRAB_MODE_ASYNC,
+        .cursor = XCB_NONE,
+        .button = XCB_BUTTON_INDEX_1,
+        .modifiers = XCB_NONE,
+};
+
 static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
-        // A simple single button press with no keyboard modifiers (sets focus)
-        {
-                .pass_event = 1,
-                .mask = DEFAULT_BUTTON_MASK,
-                .pointer_mode = XCB_GRAB_MODE_ASYNC,
-                .keyboard_mode = XCB_GRAB_MODE_ASYNC,
-                .cursor = XCB_NONE,
-                .button = XCB_BUTTON_INDEX_1,
-                .modifiers = XCB_NONE,
-        },
         {
                 .pass_event = 0,
                 .mask = DEFAULT_BUTTON_MASK,
@@ -47,5 +47,8 @@ static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
         },
 };
 
-void mouse_client_listener(const struct natwm_state *state,
-                           const struct client *client);
+void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
+                             const struct mouse_binding *binding);
+
+void mouse_initialize_client_listeners(const struct natwm_state *state,
+                                       const struct client *client);


### PR DESCRIPTION
When clicking a unfocused client that client should gain focus and be moved to the front of the screen.

When clicking a focused client without any active modifiers nothing should happen, the event should be passed to the client window as usual.