### PR TITLE
Feature/improve window focus

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -531,12 +531,12 @@ enum natwm_error client_destroy_window(struct natwm_state *state,
                 state->workspace_list, window);
 
         if (workspace == NULL) {
+                // This window is not registered with us
                 struct workspace *active_workspace
                         = workspace_list_get_focused(state->workspace_list);
 
                 workspace_reset_input_focus(state, active_workspace);
 
-                // This window is not registered with us
                 xcb_destroy_window(state->xcb, window);
 
                 return NO_ERROR;

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -531,10 +531,8 @@ enum natwm_error client_destroy_window(struct natwm_state *state,
                 state->workspace_list, window);
 
         if (workspace == NULL) {
-                struct workspace_list *workspace_list = state->workspace_list;
                 struct workspace *active_workspace
-                        = workspace_list
-                                  ->workspaces[workspace_list->active_index];
+                        = workspace_list_get_focused(state->workspace_list);
 
                 workspace_reset_input_focus(state, active_workspace);
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -67,6 +67,8 @@ uint16_t client_get_active_border_width(const struct client_theme *theme,
 struct color_value *
 client_get_active_border_color(const struct client_theme *theme,
                                const struct client *client);
+void client_set_input_focus(const struct natwm_state *state,
+                            struct client *client);
 void client_set_focused(const struct natwm_state *state, struct client *client);
 void client_set_unfocused(const struct natwm_state *state,
                           struct client *client);

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -190,6 +190,17 @@ static void focus_client(struct natwm_state *state, struct workspace *workspace,
         natwm_state_unlock(state);
 }
 
+// Focus on the root window when there is no other windows to focus
+static void reset_focus(const struct natwm_state *state)
+{
+        ewmh_update_active_window(state, state->screen->root);
+
+        xcb_set_input_focus(state->xcb,
+                            XCB_INPUT_FOCUS_NONE,
+                            state->screen->root,
+                            XCB_TIME_CURRENT_TIME);
+}
+
 struct workspace *workspace_create(const char *name, size_t index)
 {
         struct workspace *workspace = malloc(sizeof(struct workspace));
@@ -246,6 +257,8 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
 
         ewmh_update_current_desktop(state, workspace_list->active_index);
         ewmh_update_desktop_names(state, workspace_list);
+
+        reset_focus(state);
 
         *result = workspace_list;
 
@@ -331,6 +344,8 @@ enum natwm_error workspace_reset_focus(struct natwm_state *state,
 
         // There are no more clients on this workspace
         workspace->active_client = NULL;
+
+        reset_focus(state);
 
         return NOT_FOUND_ERROR;
 }

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -191,7 +191,7 @@ static void focus_client(struct natwm_state *state, struct workspace *workspace,
 }
 
 // Focus on the root window when there is no other windows to focus
-static void reset_focus(const struct natwm_state *state)
+static void reset_input_focus(const struct natwm_state *state)
 {
         ewmh_update_active_window(state, state->screen->root);
 
@@ -258,7 +258,7 @@ enum natwm_error workspace_list_init(const struct natwm_state *state,
         ewmh_update_current_desktop(state, workspace_list->active_index);
         ewmh_update_desktop_names(state, workspace_list);
 
-        reset_focus(state);
+        reset_input_focus(state);
 
         *result = workspace_list;
 
@@ -345,9 +345,35 @@ enum natwm_error workspace_reset_focus(struct natwm_state *state,
         // There are no more clients on this workspace
         workspace->active_client = NULL;
 
-        reset_focus(state);
+        reset_input_focus(state);
 
         return NOT_FOUND_ERROR;
+}
+
+// This is a more simple version of workspace_reset_focus - all it does is
+// reset the input focus of the first client it can find, falling back to the
+// root window.
+void workspace_reset_input_focus(struct natwm_state *state,
+                                 struct workspace *workspace)
+{
+        if (!workspace->is_visible) {
+                return;
+        }
+
+        LIST_FOR_EACH(workspace->clients, node)
+        {
+                struct client *client = get_client_from_client_node(node);
+
+                if (client->state == CLIENT_HIDDEN) {
+                        continue;
+                }
+
+                client_set_input_focus(state, client);
+
+                return;
+        }
+
+        reset_input_focus(state);
 }
 
 enum natwm_error workspace_add_client(struct natwm_state *state,

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -49,6 +49,8 @@ enum natwm_error workspace_focus_existing_client(struct natwm_state *state,
 enum natwm_error workspace_unfocus_existing_client(struct natwm_state *state,
                                                    struct workspace *workspace,
                                                    struct client *client);
+void workspace_reset_input_focus(struct natwm_state *state,
+                                 struct workspace *workspace);
 enum natwm_error workspace_reset_focus(struct natwm_state *state,
                                        struct workspace *workspace);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);


### PR DESCRIPTION
Fix a few input focus bugs:

- Firstly when registering a new window we would try to focus on the window before mapping the window which caused the window to remain unfocused and an invalid window to remain focused.
- When initially loading the window manager the root window was not focused. This caused an invalid window to be focused, which would cause any tool trying to read the focused window to return a `BadWindow` error
- When a window which was not registered with us was destroyed and has it's focus revert back to `root` or even worse `none` we were left with the wrong focused window. Now we will return the focus back to the currently active window on the active workspace which, while maybe not the final implementation is better than what was previously happening.