### PR TITLE
core/monitor: Store offsets seperate from monitor rect

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -2,6 +2,7 @@
 // Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <sys/select.h>
@@ -30,6 +31,8 @@ enum natwm_error config_array_to_box_sizes(const struct config_array *array,
                 if (value == NULL || value->type != NUMBER) {
                         return INVALID_INPUT_ERROR;
                 }
+
+                assert(value->data.number <= UINT16_MAX);
         }
 
         sizes.top = (uint16_t)array->values[0]->data.number;

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -317,11 +317,12 @@ struct client *client_register_window(struct natwm_state *state,
 
         // Load the client theme from the workspace list
         struct client_theme *theme = state->workspace_list->theme;
+        xcb_rectangle_t workspace_monitor_rect
+                = monitor_get_offset_rect(workspace_monitor);
 
         // Adjust window rect to fit workspace monitor
-        client->rect = client_initialize_rect(client,
-                                              theme->border_width->unfocused,
-                                              workspace_monitor->rect);
+        client->rect = client_initialize_rect(
+                client, theme->border_width->unfocused, workspace_monitor_rect);
 
         // Set the adjusted rect to the client window
         uint16_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
@@ -418,6 +419,7 @@ enum natwm_error client_configure_window(struct natwm_state *state,
                 return RESOLUTION_FAILURE;
         }
 
+        xcb_rectangle_t monitor_rect = monitor_get_offset_rect(monitor);
         xcb_rectangle_t new_rect = client->rect;
         xcb_configure_request_event_t new_event = *event;
 
@@ -453,7 +455,7 @@ enum natwm_error client_configure_window(struct natwm_state *state,
                 }
         }
 
-        client->rect = clamp_rect_to_monitor(new_rect, monitor->rect);
+        client->rect = clamp_rect_to_monitor(new_rect, monitor_rect);
 
         new_event.x = client->rect.x;
         new_event.y = client->rect.y;
@@ -500,7 +502,6 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
 
         if (workspace == NULL) {
                 // We do not have this window in our registry
-
                 xcb_unmap_window(state->xcb, window);
 
                 return NO_ERROR;

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -176,9 +176,10 @@ void ewmh_update_desktop_viewport(const struct natwm_state *state,
         LIST_FOR_EACH(list->monitors, monitor_item)
         {
                 struct monitor *monitor = (struct monitor *)monitor_item->data;
+                xcb_rectangle_t rect = monitor_get_offset_rect(monitor);
 
-                viewports[index].x = (uint32_t)monitor->rect.x;
-                viewports[index].y = (uint32_t)monitor->rect.y;
+                viewports[index].x = (uint32_t)rect.x;
+                viewports[index].y = (uint32_t)rect.y;
 
                 ++index;
         }

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -75,14 +75,7 @@ static void monitor_list_set_offsets(const struct natwm_state *state,
                         break;
                 }
 
-                // This has a possibility of overflowing if the user
-                // inputs silly data into their configuration file.
-                monitor->rect.x = (int16_t)(monitor->rect.x + offsets.left);
-                monitor->rect.y = (int16_t)(monitor->rect.y + offsets.top);
-                monitor->rect.width = (uint16_t)(
-                        monitor->rect.width - (offsets.left + offsets.right));
-                monitor->rect.height = (uint16_t)(
-                        monitor->rect.height - (offsets.top + offsets.bottom));
+                monitor->offsets = offsets;
 
                 ++index;
         }
@@ -391,6 +384,31 @@ enum natwm_error monitor_setup(const struct natwm_state *state,
         *result = monitor_list;
 
         return NO_ERROR;
+}
+
+xcb_rectangle_t monitor_get_offset_rect(const struct monitor *monitor)
+{
+        xcb_rectangle_t rect = {
+                .x = 0,
+                .y = 0,
+                .width = 0,
+                .height = 0,
+        };
+
+        if (monitor == NULL) {
+                return rect;
+        }
+
+        struct box_sizes offsets = monitor->offsets;
+
+        rect.x = (int16_t)(monitor->rect.x + offsets.left);
+        rect.y = (int16_t)(monitor->rect.y + offsets.top);
+        rect.width = (uint16_t)(monitor->rect.width
+                                - (offsets.left + offsets.right));
+        rect.height = (uint16_t)(monitor->rect.height
+                                 - (offsets.top + offsets.bottom));
+
+        return rect;
 }
 
 void monitor_list_destroy(struct monitor_list *monitor_list)

--- a/src/core/monitor.h
+++ b/src/core/monitor.h
@@ -7,6 +7,7 @@
 #include <xcb/xcb.h>
 
 #include <common/list.h>
+#include <common/types.h>
 
 #include "state.h"
 #include "workspace.h"
@@ -30,6 +31,7 @@ struct monitor {
         // contexts this is unused.
         uint32_t id;
         xcb_rectangle_t rect;
+        struct box_sizes offsets;
         struct workspace *workspace;
 };
 
@@ -52,5 +54,6 @@ struct monitor *monitor_create(uint32_t id, xcb_rectangle_t rect,
                                struct workspace *workspace);
 enum natwm_error monitor_setup(const struct natwm_state *state,
                                struct monitor_list **result);
+xcb_rectangle_t monitor_get_offset_rect(const struct monitor *monitor);
 void monitor_list_destroy(struct monitor_list *monitor_list);
 void monitor_destroy(struct monitor *monitor);


### PR DESCRIPTION
We need to know the full monitor rect in order to support full screen
windows.

Signed-off-by: Chris Frank <chris@cfrank.org>