### PR TITLE
Feature/support full screen

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -260,6 +260,7 @@ struct client *client_create(xcb_window_t window, xcb_rectangle_t rect,
         }
 
         client->is_focused = false;
+        client->is_fullscreen = false;
         client->state = CLIENT_NORMAL;
 
         return client;
@@ -643,6 +644,112 @@ client_get_active_border_color(const struct client_theme *theme,
         }
 
         return theme->color->unfocused;
+}
+
+enum natwm_error client_set_fullscreen(const struct natwm_state *state,
+                                       struct client *client)
+{
+        struct workspace *workspace = workspace_list_find_client_workspace(
+                state->workspace_list, client);
+
+        if (workspace == NULL) {
+                return NOT_FOUND_ERROR;
+        }
+
+        struct monitor *monitor = monitor_list_get_workspace_monitor(
+                state->monitor_list, workspace);
+
+        if (monitor == NULL) {
+                return RESOLUTION_FAILURE;
+        }
+
+        uint16_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
+                | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT
+                | XCB_CONFIG_WINDOW_BORDER_WIDTH;
+        uint32_t values[] = {
+                (uint16_t)monitor->rect.x,
+                (uint16_t)monitor->rect.y,
+                monitor->rect.width,
+                monitor->rect.height,
+                0,
+        };
+
+        client->is_fullscreen = true;
+
+        xcb_atom_t atoms[] = {
+                state->ewmh->_NET_WM_STATE_FULLSCREEN,
+        };
+
+        ewmh_add_wm_state_values(state, atoms, 1, client->window);
+
+        xcb_configure_window(state->xcb, client->window, mask, values);
+
+        return NO_ERROR;
+}
+
+enum natwm_error client_unset_fullscreen(struct natwm_state *state,
+                                         struct client *client)
+{
+        struct workspace *workspace = workspace_list_find_client_workspace(
+                state->workspace_list, client);
+
+        if (workspace == NULL) {
+                return NOT_FOUND_ERROR;
+        }
+
+        struct client_theme *theme = state->workspace_list->theme;
+        uint16_t border_width = client_get_active_border_width(theme, client);
+        uint16_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
+                | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT
+                | XCB_CONFIG_WINDOW_BORDER_WIDTH;
+        uint32_t values[] = {
+                (uint16_t)client->rect.x,
+                (uint16_t)client->rect.y,
+                client->rect.width,
+                client->rect.height,
+                border_width,
+        };
+
+        client->is_fullscreen = false;
+
+        xcb_atom_t atoms[] = {
+                state->ewmh->_NET_WM_STATE_FULLSCREEN,
+        };
+
+        ewmh_remove_wm_state_values(state, atoms, 1, client->window);
+
+        xcb_configure_window(state->xcb, client->window, mask, values);
+
+        return NO_ERROR;
+}
+
+enum natwm_error
+client_handle_fullscreen_window(struct natwm_state *state,
+                                xcb_ewmh_wm_state_action_t action,
+                                xcb_window_t window)
+{
+        struct workspace *workspace = workspace_list_find_window_workspace(
+                state->workspace_list, window);
+
+        if (workspace == NULL) {
+                // window is not registered with us - just ignore it
+                return NO_ERROR;
+        }
+
+        struct client *client = workspace_find_window_client(workspace, window);
+
+        switch (action) {
+        case XCB_EWMH_WM_STATE_ADD:
+                return client_set_fullscreen(state, client);
+        case XCB_EWMH_WM_STATE_REMOVE:
+                return client_unset_fullscreen(state, client);
+        case XCB_EWMH_WM_STATE_TOGGLE:
+                return (client->is_fullscreen)
+                        ? client_unset_fullscreen(state, client)
+                        : client_set_fullscreen(state, client);
+        }
+
+        return GENERIC_ERROR;
 }
 
 void client_set_input_focus(const struct natwm_state *state,

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -177,6 +177,11 @@ static xcb_rectangle_t clamp_rect_to_monitor(xcb_rectangle_t rect,
 static void update_theme(const struct natwm_state *state, struct client *client,
                          uint16_t previous_border_width)
 {
+        if (client->is_fullscreen) {
+                // No need to upate theme if client is fullscreen
+                return;
+        }
+
         uint16_t current_border_width = client_get_active_border_width(
                 state->workspace_list->theme, client);
         const struct color_value *border_color = client_get_active_border_color(

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <xcb/xcb.h>
+#include <xcb/xcb_ewmh.h>
 #include <xcb/xcb_icccm.h>
 
 #include <common/error.h>
@@ -44,6 +45,7 @@ struct client {
         xcb_rectangle_t rect;
         xcb_size_hints_t *size_hints;
         bool is_focused;
+        bool is_fullscreen;
         enum client_state state;
 };
 
@@ -67,6 +69,14 @@ uint16_t client_get_active_border_width(const struct client_theme *theme,
 struct color_value *
 client_get_active_border_color(const struct client_theme *theme,
                                const struct client *client);
+enum natwm_error client_unset_fullscreen(struct natwm_state *state,
+                                         struct client *client);
+enum natwm_error client_set_fullscreen(const struct natwm_state *state,
+                                       struct client *client);
+enum natwm_error
+client_handle_fullscreen_window(struct natwm_state *state,
+                                xcb_ewmh_wm_state_action_t action,
+                                xcb_window_t window);
 void client_set_input_focus(const struct natwm_state *state,
                             struct client *client);
 void client_set_focused(const struct natwm_state *state, struct client *client);

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -70,8 +70,6 @@ void ewmh_init(const struct natwm_state *state)
         xcb_atom_t net_atoms[] = {
                 // Root window properties
                 state->ewmh->_NET_SUPPORTED,
-                state->ewmh->_NET_CLIENT_LIST,
-                state->ewmh->_NET_CLIENT_LIST_STACKING,
                 state->ewmh->_NET_NUMBER_OF_DESKTOPS,
                 state->ewmh->_NET_DESKTOP_VIEWPORT,
                 state->ewmh->_NET_CURRENT_DESKTOP,
@@ -86,22 +84,12 @@ void ewmh_init(const struct natwm_state *state)
                 state->ewmh->_NET_WM_DESKTOP,
                 state->ewmh->_NET_WM_WINDOW_TYPE,
                 state->ewmh->_NET_WM_STATE,
-                state->ewmh->_NET_WM_ALLOWED_ACTIONS,
-                state->ewmh->_NET_WM_STRUT,
-                state->ewmh->_NET_WM_STRUT_PARTIAL,
                 state->ewmh->_NET_WM_PID,
                 // Window types
                 // TODO: Add more
-                state->ewmh->_NET_WM_WINDOW_TYPE_DOCK,
-                state->ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR,
-                state->ewmh->_NET_WM_WINDOW_TYPE_SPLASH,
                 state->ewmh->_NET_WM_WINDOW_TYPE_NORMAL,
                 // Window States
-                state->ewmh->_NET_WM_STATE_STICKY,
-                state->ewmh->_NET_WM_STATE_MAXIMIZED_VERT,
-                state->ewmh->_NET_WM_STATE_MAXIMIZED_HORZ,
                 state->ewmh->_NET_WM_STATE_FULLSCREEN,
-                state->ewmh->_NET_WM_STATE_DEMANDS_ATTENTION,
         };
 
         size_t len = (sizeof(net_atoms) / sizeof(xcb_atom_t));
@@ -119,6 +107,8 @@ void ewmh_init(const struct natwm_state *state)
 
         xcb_ewmh_set_supporting_wm_check(
                 state->ewmh, state->screen->root, supporting_win);
+        xcb_ewmh_set_supporting_wm_check(
+                state->ewmh, supporting_win, supporting_win);
 
         // Set the WM name on the supporting win
         xcb_ewmh_set_wm_name(state->ewmh,

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -4,14 +4,26 @@
 
 #pragma once
 
+#include <xcb/xcb.h>
 #include <xcb/xcb_ewmh.h>
 
+#include "client.h"
+#include "monitor.h"
 #include "state.h"
+#include "workspace.h"
 
 xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
 bool ewmh_is_normal_window(const struct natwm_state *state,
                            xcb_window_t window);
+enum natwm_error ewmh_add_wm_state_values(const struct natwm_state *state,
+                                          xcb_atom_t *atoms,
+                                          size_t atoms_length,
+                                          xcb_window_t window);
+enum natwm_error ewmh_remove_wm_state_values(const struct natwm_state *state,
+                                             xcb_atom_t *atoms,
+                                             size_t atoms_length,
+                                             xcb_window_t window);
 void ewmh_update_active_window(const struct natwm_state *state,
                                xcb_window_t window);
 void ewmh_update_desktop_viewport(const struct natwm_state *state,


### PR DESCRIPTION
Handle `XCB_CLIENT_MESSAGE` events and within that handle `_NET_WM_STATE_FULLSCREEN` changes which allow for making clients fullscreen.

There are still some bugs in this implementation, but they will be addressed in future PRs 