### PR TITLE
Feature/handle net active window

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
             - libxcb-keysyms1-dev
             - libxcb-ewmh-dev
             - libxcb-icccm4-dev
+            - libxcb-util-dev
 
 cache:
     apt: true

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -35,5 +35,6 @@ target_link_libraries(core
         xcb-ewmh
         xcb-icccm
         xcb-randr
+        xcb-util
         xcb-xinerama
 )

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -12,6 +12,7 @@
 #include "ewmh.h"
 #include "monitor.h"
 #include "mouse.h"
+#include "workspace.h"
 
 static void configure_window(xcb_connection_t *connection,
                              xcb_configure_request_event_t *event)

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -12,7 +12,6 @@
 #include "ewmh.h"
 #include "monitor.h"
 #include "mouse.h"
-#include "workspace.h"
 
 static void configure_window(xcb_connection_t *connection,
                              xcb_configure_request_event_t *event)
@@ -225,17 +224,14 @@ static void update_theme(const struct natwm_state *state, struct client *client,
 }
 
 static void update_stack_mode(const struct natwm_state *state,
-                              const struct client *client,
-                              xcb_stack_mode_t stack_mode)
+                              xcb_window_t window, xcb_stack_mode_t stack_mode)
 {
         uint32_t values[] = {
                 stack_mode,
         };
 
-        xcb_configure_window(state->xcb,
-                             client->window,
-                             XCB_CONFIG_WINDOW_STACK_MODE,
-                             values);
+        xcb_configure_window(
+                state->xcb, window, XCB_CONFIG_WINDOW_STACK_MODE, values);
 
         xcb_flush(state->xcb);
 }
@@ -656,11 +652,6 @@ enum natwm_error client_set_fullscreen(const struct natwm_state *state,
 {
         struct workspace *workspace = workspace_list_find_client_workspace(
                 state->workspace_list, client);
-
-        if (workspace == NULL) {
-                return NOT_FOUND_ERROR;
-        }
-
         struct monitor *monitor = monitor_list_get_workspace_monitor(
                 state->monitor_list, workspace);
 
@@ -681,27 +672,17 @@ enum natwm_error client_set_fullscreen(const struct natwm_state *state,
 
         client->is_fullscreen = true;
 
-        xcb_atom_t atoms[] = {
-                state->ewmh->_NET_WM_STATE_FULLSCREEN,
-        };
-
-        ewmh_add_wm_state_values(state, atoms, 1, client->window);
+        ewmh_add_window_state(
+                state, client->window, state->ewmh->_NET_WM_STATE_FULLSCREEN);
 
         xcb_configure_window(state->xcb, client->window, mask, values);
 
         return NO_ERROR;
 }
 
-enum natwm_error client_unset_fullscreen(struct natwm_state *state,
+enum natwm_error client_unset_fullscreen(const struct natwm_state *state,
                                          struct client *client)
 {
-        struct workspace *workspace = workspace_list_find_client_workspace(
-                state->workspace_list, client);
-
-        if (workspace == NULL) {
-                return NOT_FOUND_ERROR;
-        }
-
         struct client_theme *theme = state->workspace_list->theme;
         uint16_t border_width = client_get_active_border_width(theme, client);
         uint16_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
@@ -717,11 +698,7 @@ enum natwm_error client_unset_fullscreen(struct natwm_state *state,
 
         client->is_fullscreen = false;
 
-        xcb_atom_t atoms[] = {
-                state->ewmh->_NET_WM_STATE_FULLSCREEN,
-        };
-
-        ewmh_remove_wm_state_values(state, atoms, 1, client->window);
+        ewmh_remove_window_state(state, client->window);
 
         xcb_configure_window(state->xcb, client->window, mask, values);
 
@@ -733,15 +710,12 @@ client_handle_fullscreen_window(struct natwm_state *state,
                                 xcb_ewmh_wm_state_action_t action,
                                 xcb_window_t window)
 {
-        struct workspace *workspace = workspace_list_find_window_workspace(
+        struct client *client = workspace_list_find_window_client(
                 state->workspace_list, window);
 
-        if (workspace == NULL) {
-                // window is not registered with us - just ignore it
-                return NO_ERROR;
+        if (client == NULL) {
+                return NOT_FOUND_ERROR;
         }
-
-        struct client *client = workspace_find_window_client(workspace, window);
 
         switch (action) {
         case XCB_EWMH_WM_STATE_ADD:
@@ -757,15 +731,17 @@ client_handle_fullscreen_window(struct natwm_state *state,
         return GENERIC_ERROR;
 }
 
-void client_set_input_focus(const struct natwm_state *state,
-                            struct client *client)
+void client_set_window_input_focus(const struct natwm_state *state,
+                                   xcb_window_t window)
 {
-        ewmh_update_active_window(state, client->window);
+        ewmh_update_active_window(state, window);
 
         xcb_set_input_focus(state->xcb,
                             XCB_INPUT_FOCUS_POINTER_ROOT,
-                            client->window,
+                            window,
                             XCB_TIME_CURRENT_TIME);
+
+        update_stack_mode(state, window, XCB_STACK_MODE_ABOVE);
 }
 
 void client_set_focused(const struct natwm_state *state, struct client *client)
@@ -778,13 +754,7 @@ void client_set_focused(const struct natwm_state *state, struct client *client)
 
         client->is_focused = true;
 
-        client_set_input_focus(state, client);
-
-        update_stack_mode(state, client, XCB_STACK_MODE_ABOVE);
-
-        if (client->state != CLIENT_NORMAL) {
-                return;
-        }
+        client_set_window_input_focus(state, client->window);
 
         // Now that we have focused the client, there is no need for "click to
         // focus" so we can remove the button grab
@@ -792,6 +762,10 @@ void client_set_focused(const struct natwm_state *state, struct client *client)
                           client_focus_event.button,
                           client->window,
                           client_focus_event.modifiers);
+
+        if (client->state != CLIENT_NORMAL) {
+                return;
+        }
 
         update_theme(state, client, theme->border_width->unfocused);
 }
@@ -807,16 +781,33 @@ void client_set_unfocused(const struct natwm_state *state,
 
         client->is_focused = false;
 
-        if (client->state != CLIENT_NORMAL) {
-                return;
-        }
-
         // When a client is unfocused we need to grab the mouse button required
         // for "click to focus"
         mouse_event_grab_button(
                 state->xcb, client->window, &client_focus_event);
 
+        if (client->state != CLIENT_NORMAL) {
+                return;
+        }
+
         update_theme(state, client, theme->border_width->focused);
+}
+
+enum natwm_error client_focus_window(const struct natwm_state *state,
+                                     xcb_window_t window)
+{
+        struct client *client = workspace_list_find_window_client(
+                state->workspace_list, window);
+
+        if (client == NULL) {
+                client_set_window_input_focus(state, window);
+
+                return NO_ERROR;
+        }
+
+        client_set_focused(state, client);
+
+        return NO_ERROR;
 }
 
 enum natwm_error client_update_hints(const struct natwm_state *state,

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -69,7 +69,7 @@ uint16_t client_get_active_border_width(const struct client_theme *theme,
 struct color_value *
 client_get_active_border_color(const struct client_theme *theme,
                                const struct client *client);
-enum natwm_error client_unset_fullscreen(struct natwm_state *state,
+enum natwm_error client_unset_fullscreen(const struct natwm_state *state,
                                          struct client *client);
 enum natwm_error client_set_fullscreen(const struct natwm_state *state,
                                        struct client *client);
@@ -77,11 +77,13 @@ enum natwm_error
 client_handle_fullscreen_window(struct natwm_state *state,
                                 xcb_ewmh_wm_state_action_t action,
                                 xcb_window_t window);
-void client_set_input_focus(const struct natwm_state *state,
-                            struct client *client);
+void client_set_window_input_focus(const struct natwm_state *state,
+                                   xcb_window_t window);
 void client_set_focused(const struct natwm_state *state, struct client *client);
 void client_set_unfocused(const struct natwm_state *state,
                           struct client *client);
+enum natwm_error client_focus_window(const struct natwm_state *state,
+                                     xcb_window_t window);
 enum natwm_error client_update_hints(const struct natwm_state *state,
                                      const struct client *client,
                                      enum client_hints hints);

--- a/src/core/ewmh.c
+++ b/src/core/ewmh.c
@@ -148,92 +148,30 @@ bool ewmh_is_normal_window(const struct natwm_state *state, xcb_window_t window)
         return true;
 }
 
-enum natwm_error ewmh_add_wm_state_values(const struct natwm_state *state,
-                                          xcb_atom_t *atoms,
-                                          size_t atoms_length,
-                                          xcb_window_t window)
+void ewmh_add_window_state(const struct natwm_state *state, xcb_window_t window,
+                           xcb_atom_t atom)
 {
-        xcb_ewmh_get_atoms_reply_t data;
-        xcb_get_property_cookie_t cookie
-                = xcb_ewmh_get_wm_state(state->ewmh, window);
-
-        if (!xcb_ewmh_get_wm_state_reply(state->ewmh, cookie, &data, NULL)) {
-                return RESOLUTION_FAILURE;
-        }
-
-        uint32_t list_length = (uint32_t)(data.atoms_len + atoms_length);
-        xcb_atom_t *list = malloc(sizeof(xcb_atom_t) * list_length);
-
-        if (list == NULL) {
-                xcb_ewmh_get_atoms_reply_wipe(&data);
-
-                return MEMORY_ALLOCATION_ERROR;
-        }
-
-        memcpy(list, data.atoms, sizeof(xcb_atom_t));
-
-        for (size_t i = (data.atoms_len - 1); i < atoms_length; ++i) {
-                list[i] = atoms[(i - data.atoms_len) - 1];
-        }
-
-        xcb_ewmh_set_wm_state(state->ewmh, window, list_length, list);
-
-        free(list);
-
-        xcb_ewmh_get_atoms_reply_wipe(&data);
-
-        return NO_ERROR;
+        xcb_change_property(state->xcb,
+                            XCB_PROP_MODE_REPLACE,
+                            window,
+                            state->ewmh->_NET_WM_STATE,
+                            XCB_ATOM_ATOM,
+                            32,
+                            1,
+                            &atom);
 }
 
-enum natwm_error ewmh_remove_wm_state_values(const struct natwm_state *state,
-                                             xcb_atom_t *atoms,
-                                             size_t atoms_length,
-                                             xcb_window_t window)
+void ewmh_remove_window_state(const struct natwm_state *state,
+                              xcb_window_t window)
 {
-        xcb_ewmh_get_atoms_reply_t data;
-        xcb_get_property_cookie_t cookie
-                = xcb_ewmh_get_wm_state_unchecked(state->ewmh, window);
-
-        if (!xcb_ewmh_get_wm_state_reply(state->ewmh, cookie, &data, NULL)) {
-                return RESOLUTION_FAILURE;
-        }
-
-        xcb_atom_t *list = malloc(sizeof(xcb_atom_t) * data.atoms_len);
-
-        if (list == NULL) {
-                xcb_ewmh_get_atoms_reply_wipe(&data);
-
-                return MEMORY_ALLOCATION_ERROR;
-        }
-
-        uint32_t list_length = 0;
-
-        for (size_t i = 0; i < data.atoms_len; ++i) {
-                for (size_t j = 0; j < atoms_length; ++j) {
-                        if (data.atoms[i] == atoms[j]) {
-                                goto cont;
-                        }
-                }
-
-                list[list_length] = data.atoms[i];
-                list_length++;
-
-        cont:
-                continue;
-        }
-
-        if (list_length == data.atoms_len) {
-                // We didn't do anything
-                return NO_ERROR;
-        }
-
-        xcb_ewmh_set_wm_state(state->ewmh, window, list_length, list);
-
-        free(list);
-
-        xcb_ewmh_get_atoms_reply_wipe(&data);
-
-        return NO_ERROR;
+        xcb_change_property(state->xcb,
+                            XCB_PROP_MODE_REPLACE,
+                            window,
+                            state->ewmh->_NET_WM_STATE,
+                            XCB_ATOM_ATOM,
+                            32,
+                            0,
+                            NULL);
 }
 
 void ewmh_update_active_window(const struct natwm_state *state,

--- a/src/core/ewmh.h
+++ b/src/core/ewmh.h
@@ -16,14 +16,10 @@ xcb_ewmh_connection_t *ewmh_create(xcb_connection_t *xcb_connection);
 void ewmh_init(const struct natwm_state *state);
 bool ewmh_is_normal_window(const struct natwm_state *state,
                            xcb_window_t window);
-enum natwm_error ewmh_add_wm_state_values(const struct natwm_state *state,
-                                          xcb_atom_t *atoms,
-                                          size_t atoms_length,
-                                          xcb_window_t window);
-enum natwm_error ewmh_remove_wm_state_values(const struct natwm_state *state,
-                                             xcb_atom_t *atoms,
-                                             size_t atoms_length,
-                                             xcb_window_t window);
+void ewmh_add_window_state(const struct natwm_state *state, xcb_window_t window,
+                           xcb_atom_t atom);
+void ewmh_remove_window_state(const struct natwm_state *state,
+                              xcb_window_t window);
 void ewmh_update_active_window(const struct natwm_state *state,
                                xcb_window_t window);
 void ewmh_update_desktop_viewport(const struct natwm_state *state,

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -368,7 +368,7 @@ void workspace_reset_input_focus(struct natwm_state *state,
                         continue;
                 }
 
-                client_set_input_focus(state, client);
+                client_set_window_input_focus(state, client->window);
 
                 return;
         }


### PR DESCRIPTION
Fixes #80 

Allows for handling the following new events:
- XCB_CIRCULATE_EVENT
- _NET_ACTIVE_WINDOW XCB_CLIENT_MESSAGE event

Fixes issue with setting _NET_WM_STATE flag after moving to full screen window

Cleans up client code a bit