### PR TITLE
Support switching workspaces with multiple monitors

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -493,8 +493,6 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
 
         if (workspace == NULL) {
                 // We do not have this window in our registry
-                xcb_unmap_window(state->xcb, window);
-
                 return NO_ERROR;
         }
 
@@ -504,14 +502,10 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
                 LOG_ERROR(natwm_logger,
                           "Failed to find registered client during unmap");
 
-                xcb_unmap_window(state->xcb, window);
-
                 return NOT_FOUND_ERROR;
         }
 
         if (client->state & CLIENT_OFF_SCREEN) {
-                xcb_unmap_window(state->xcb, client->window);
-
                 return NO_ERROR;
         }
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -63,6 +63,8 @@ void client_configure_window_rect(xcb_connection_t *connection,
                                   uint32_t border_width);
 void client_map(const struct natwm_state *state, struct client *client,
                 xcb_rectangle_t monitor_rect);
+enum natwm_error client_handle_map_notify(const struct natwm_state *state,
+                                          xcb_window_t window);
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
 enum natwm_error client_destroy_window(struct natwm_state *state,

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -100,6 +100,16 @@ static enum natwm_error event_handle_map_request(struct natwm_state *state,
         return NO_ERROR;
 }
 
+static enum natwm_error event_handle_map_notify(struct natwm_state *state,
+                                                xcb_map_notify_event_t *event)
+{
+        xcb_window_t window = event->window;
+
+        client_handle_map_notify(state, window);
+
+        return NO_ERROR;
+}
+
 static enum natwm_error
 event_handle_unmap_notify(struct natwm_state *state,
                           xcb_unmap_notify_event_t *event)
@@ -140,6 +150,10 @@ enum natwm_error event_handle(struct natwm_state *state,
         case XCB_MAP_REQUEST:
                 return event_handle_map_request(
                         state, (xcb_map_request_event_t *)event);
+                break;
+        case XCB_MAP_NOTIFY:
+                return event_handle_map_notify(state,
+                                               (xcb_map_notify_event_t *)event);
                 break;
         case XCB_UNMAP_NOTIFY:
                 return event_handle_unmap_notify(

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -49,8 +49,6 @@ enum natwm_error workspace_focus_existing_client(struct natwm_state *state,
 enum natwm_error workspace_unfocus_existing_client(struct natwm_state *state,
                                                    struct workspace *workspace,
                                                    struct client *client);
-void workspace_reset_input_focus(struct natwm_state *state,
-                                 struct workspace *workspace);
 enum natwm_error workspace_reset_focus(struct natwm_state *state,
                                        struct workspace *workspace);
 enum natwm_error workspace_change_monitor(struct natwm_state *state,


### PR DESCRIPTION
Support switching workspaces where there are multiple monitors present

Fixes #83 

Work done in this PR:

- The unmap_notify event is a notify event not a request. Previously we were treating this event as a request event which was incorrect
- Support mapping clients on monitors besides the one at 
- Update a bunch of the workspace code to support switching/hiding simultaneously
- Handle removing CLIENT_OFF_SCREEN inside of a map_notify 
- General refactoring