### PR TITLE
Fix/sizing of new clients

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -163,19 +163,27 @@ static void update_theme(const struct natwm_state *state, struct client *client,
         xcb_rectangle_t monitor_rect = monitor_get_offset_rect(monitor);
 
         int32_t total_border = (current_border_width * 2);
-        int32_t total_width = client->rect.width + total_border;
-        int32_t total_height = client->rect.height + total_border;
+
+        int32_t total_client_width
+                = (client->rect.width + client->rect.x + total_border);
+        int32_t total_monitor_width
+                = (monitor_rect.width + monitor->offsets.left);
+
+        int32_t total_client_height
+                = (client->rect.height + client->rect.y + total_border);
+        int32_t total_monitor_height
+                = (monitor_rect.height + monitor->offsets.top);
 
         // Check if either the width or the height will not be able to fit on
         // the monitor. If either doesn't correct the width to fit
-        if (total_width > monitor_rect.width) {
-                int32_t diff = total_width - monitor_rect.width;
+        if (total_client_width > total_monitor_width) {
+                int32_t diff = total_client_width - total_monitor_width;
 
                 client->rect.width = (uint16_t)(client->rect.width - diff);
         }
 
-        if (total_height > monitor_rect.height) {
-                int32_t diff = total_height - monitor_rect.height;
+        if (total_client_height > total_monitor_height) {
+                int32_t diff = total_client_height - total_monitor_height;
 
                 client->rect.height = (uint16_t)(client->rect.height - diff);
         }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -558,8 +558,8 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
         return NO_ERROR;
 }
 
-enum natwm_error client_destroy_window(struct natwm_state *state,
-                                       xcb_window_t window)
+enum natwm_error client_handle_destroy_notify(struct natwm_state *state,
+                                              xcb_window_t window)
 {
         struct workspace *workspace = workspace_list_find_window_workspace(
                 state->workspace_list, window);
@@ -571,8 +571,6 @@ enum natwm_error client_destroy_window(struct natwm_state *state,
 
                 workspace_reset_focus(state, active_workspace);
 
-                xcb_destroy_window(state->xcb, window);
-
                 return NO_ERROR;
         }
 
@@ -581,8 +579,6 @@ enum natwm_error client_destroy_window(struct natwm_state *state,
         if (client == NULL) {
                 LOG_WARNING(natwm_logger,
                             "Failed to find client during destroy");
-
-                xcb_destroy_window(state->xcb, window);
 
                 return NOT_FOUND_ERROR;
         }
@@ -598,8 +594,6 @@ enum natwm_error client_destroy_window(struct natwm_state *state,
         }
 
         xcb_change_save_set(state->xcb, XCB_SET_MODE_DELETE, client->window);
-
-        xcb_destroy_window(state->xcb, client->window);
 
         client_destroy(client);
 

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -178,7 +178,9 @@ static void update_theme(const struct natwm_state *state, struct client *client,
 
         // If this is the first time the client has been themed, we need to
         // update the clients state to remove UNTHEMED
-        client->state &= (uint8_t)~CLIENT_UNTHEMED;
+        if (client->state & CLIENT_UNTHEMED) {
+                client->state &= (uint8_t)~CLIENT_UNTHEMED;
+        }
 
         if (previous_border_width == current_border_width) {
                 return;

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -169,14 +169,12 @@ static void update_theme(const struct natwm_state *state, struct client *client,
         // Check if either the width or the height will not be able to fit on
         // the monitor. If either doesn't correct the width to fit
         if (total_width > monitor_rect.width) {
-                LOG_INFO(natwm_logger, "Width is wrong");
                 int32_t diff = total_width - monitor_rect.width;
 
                 client->rect.width = (uint16_t)(client->rect.width - diff);
         }
 
         if (total_height > monitor_rect.height) {
-                LOG_INFO(natwm_logger, "Height is wrong");
                 int32_t diff = total_height - monitor_rect.height;
 
                 client->rect.height = (uint16_t)(client->rect.height - diff);

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -553,7 +553,9 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
                 client->state |= CLIENT_HIDDEN;
         }
 
-        workspace_reset_focus(state, workspace);
+        if (client->is_focused) {
+                workspace_reset_focus(state, workspace);
+        }
 
         return NO_ERROR;
 }
@@ -825,6 +827,10 @@ enum natwm_error client_focus_window(struct natwm_state *state,
         if (client == NULL) {
                 client_set_window_input_focus(state, window);
 
+                return NO_ERROR;
+        }
+
+        if (client->is_focused) {
                 return NO_ERROR;
         }
 

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -72,9 +72,6 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
 enum natwm_error client_handle_destroy_notify(struct natwm_state *state,
                                               xcb_window_t window);
-xcb_rectangle_t client_initialize_rect(const struct client *client,
-                                       const struct monitor *monitor,
-                                       uint16_t border_width);
 uint16_t client_get_active_border_width(const struct client_theme *theme,
                                         const struct client *client);
 struct color_value *

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -21,9 +21,10 @@ struct monitor;
 enum client_state {
         CLIENT_URGENT = 1U << 0U,
         CLIENT_STICKY = 1U << 1U,
-        CLIENT_HIDDEN = 1U << 2U,
-        CLIENT_OFF_SCREEN = 1U << 3U,
-        CLIENT_NORMAL = 1U << 4U,
+        CLIENT_HIDDEN = 1U << 2U, // Client is not mapped on any screen
+        CLIENT_OFF_SCREEN = 1U << 3U, // Client isn't visible on a screen
+        CLIENT_UNTHEMED = 1U << 4U, // We haven't added a border to this window
+        CLIENT_NORMAL = 1U << 5U,
 };
 
 enum client_hints {

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -70,8 +70,8 @@ enum natwm_error client_handle_map_notify(const struct natwm_state *state,
                                           xcb_window_t window);
 enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
-enum natwm_error client_destroy_window(struct natwm_state *state,
-                                       xcb_window_t window);
+enum natwm_error client_handle_destroy_notify(struct natwm_state *state,
+                                              xcb_window_t window);
 xcb_rectangle_t client_initialize_rect(const struct client *client,
                                        const struct monitor *monitor,
                                        uint16_t border_width);

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -73,7 +73,7 @@ event_handle_destroy_notify(struct natwm_state *state,
                             xcb_destroy_notify_event_t *event)
 {
         xcb_window_t window = event->window;
-        enum natwm_error err = client_destroy_window(state, window);
+        enum natwm_error err = client_handle_destroy_notify(state, window);
 
         if (err != NO_ERROR) {
                 // A failure here would corrupt the integrity of the workspace

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -47,14 +47,14 @@ void workspace_set_focused(const struct natwm_state *state,
                            struct workspace *workspace);
 void workspace_set_unfocused(const struct natwm_state *state,
                              struct workspace *workspace);
+void workspace_reset_focus(struct natwm_state *state,
+                           struct workspace *workspace);
 enum natwm_error workspace_focus_client(struct natwm_state *state,
                                         struct workspace *workspace,
                                         struct client *client);
 enum natwm_error workspace_unfocus_client(struct natwm_state *state,
                                           struct workspace *workspace,
                                           struct client *client);
-enum natwm_error workspace_reset_focus(struct natwm_state *state,
-                                       struct workspace *workspace);
 enum natwm_error workspace_change_monitor(struct natwm_state *state,
                                           struct workspace *workspace);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);

--- a/src/core/xinerama.c
+++ b/src/core/xinerama.c
@@ -92,4 +92,3 @@ enum natwm_error xinerama_get_screens(const struct natwm_state *state,
 
         return NO_ERROR;
 }
-


### PR DESCRIPTION
Fixes #85 

There are a number of issues which this PR solves:
- Destroy notify is now handled correctly
- - 5a88ec3f5f871d01a6f1edc54f5ff8b85cb4cbad
- Optimize update_theme
- - e8d9a7301dd27d3a610343f05006ac9f748fd0b7
- - 16010891729f9c2b9fe4c36c217ea8ee26e420f8
- - 78f2356f001bbe8fd2e85ace9b7779633cbf1dd3
- Correctly account for unthemed clients in update_theme
- - 13e94620f3d2a3f273b97acc48ba4f6a10c075eb
- Fix issue with `workspace_reset_focus` for off screen clients

This PR optimizes and corrects the rect clamping code, and has passed all manual tests that we currently have.