### PR TITLE
Feature/move clients to workspace index

### DIFF
--- a/src/common/theme.h
+++ b/src/common/theme.h
@@ -52,8 +52,23 @@ struct border_theme {
         uint16_t sticky;
 };
 
+/**
+ * This is the global theme for all clients.
+ *
+ * The values are user configurable and define the look and feel of the client
+ * when it is rendered to the screen.
+ */
+struct theme {
+        struct border_theme *border_width;
+        struct color_theme *color;
+};
+
 struct border_theme *border_theme_create(void);
 struct color_theme *color_theme_create(void);
+struct theme *theme_create(const struct map *config_map);
+
+bool color_value_has_changed(struct color_value *value,
+                             const char *new_string_value);
 enum natwm_error color_value_from_string(const char *string,
                                          struct color_value **result);
 enum natwm_error border_theme_from_config(const struct map *map,
@@ -63,8 +78,8 @@ enum natwm_error color_value_from_config(const struct map *map, const char *key,
                                          struct color_value **result);
 enum natwm_error color_theme_from_config(const struct map *map, const char *key,
                                          struct color_theme **result);
-bool color_value_has_changed(struct color_value *value,
-                             const char *new_string_value);
+
 void border_theme_destroy(struct border_theme *theme);
 void color_theme_destroy(struct color_theme *theme);
 void color_value_destroy(struct color_value *value);
+void theme_destroy(struct theme *theme);

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -889,10 +889,6 @@ enum natwm_error client_send_window_to_workspace(struct natwm_state *state,
                 = workspace_list_send_to_workspace(state, client, index);
 
         if (err != NO_ERROR) {
-                LOG_ERROR(natwm_logger,
-                          "Failed to send client to workspace %zu",
-                          index);
-
                 return err;
         }
 

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -363,6 +363,8 @@ struct client *client_register_window(struct natwm_state *state,
                 goto handle_error;
         }
 
+        client_set_focused(state, client);
+
         client_update_hints(state, client, CLIENT_HINTS_ALL);
 
         return client;
@@ -868,6 +870,31 @@ enum natwm_error client_focus_window(struct natwm_state *state,
         }
 
         client_set_focused(state, client);
+
+        return NO_ERROR;
+}
+
+enum natwm_error client_send_window_to_workspace(struct natwm_state *state,
+                                                 xcb_window_t window,
+                                                 size_t index)
+{
+        struct client *client = workspace_list_find_window_client(
+                state->workspace_list, window);
+
+        if (!client) {
+                return NO_ERROR;
+        }
+
+        enum natwm_error err
+                = workspace_list_send_to_workspace(state, client, index);
+
+        if (err != NO_ERROR) {
+                LOG_ERROR(natwm_logger,
+                          "Failed to send client to workspace %zu",
+                          index);
+
+                return err;
+        }
 
         return NO_ERROR;
 }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -188,8 +188,24 @@ static void update_theme(const struct natwm_state *state, struct client *client,
 
         struct workspace *workspace = workspace_list_find_client_workspace(
                 state->workspace_list, client);
+
+        if (workspace == NULL) {
+                LOG_WARNING(natwm_logger,
+                            "Failed to find workspace during update_theme");
+
+                return;
+        }
+
         struct monitor *monitor = monitor_list_get_workspace_monitor(
                 state->monitor_list, workspace);
+
+        if (monitor == NULL) {
+                LOG_WARNING(natwm_logger,
+                            "Failed to find monitor during update_theme");
+
+                return;
+        }
+
         xcb_rectangle_t monitor_rect = monitor_get_offset_rect(monitor);
 
         int32_t total_border = (current_border_width * 2);

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -510,7 +510,7 @@ void client_map(const struct natwm_state *state, struct client *client,
                 return;
         }
 
-        struct client_theme *theme = state->workspace_list->theme;
+        struct theme *theme = state->workspace_list->theme;
         uint32_t border_width = client_get_active_border_width(theme, client);
 
         if (client->is_fullscreen) {
@@ -647,7 +647,7 @@ enum natwm_error client_handle_destroy_notify(struct natwm_state *state,
         return NO_ERROR;
 }
 
-uint16_t client_get_active_border_width(const struct client_theme *theme,
+uint16_t client_get_active_border_width(const struct theme *theme,
                                         const struct client *client)
 {
         if (client->is_fullscreen) {
@@ -673,9 +673,8 @@ uint16_t client_get_active_border_width(const struct client_theme *theme,
         return theme->border_width->unfocused;
 }
 
-struct color_value *
-client_get_active_border_color(const struct client_theme *theme,
-                               const struct client *client)
+struct color_value *client_get_active_border_color(const struct theme *theme,
+                                                   const struct client *client)
 {
         if (client->state & CLIENT_URGENT) {
                 return theme->color->urgent;
@@ -722,7 +721,7 @@ enum natwm_error client_set_fullscreen(const struct natwm_state *state,
 enum natwm_error client_unset_fullscreen(const struct natwm_state *state,
                                          struct client *client)
 {
-        struct client_theme *theme = state->workspace_list->theme;
+        struct theme *theme = state->workspace_list->theme;
         uint16_t border_width = client_get_active_border_width(theme, client);
 
         client->is_fullscreen = false;
@@ -789,7 +788,7 @@ void client_set_focused(struct natwm_state *state, struct client *client)
                 return;
         }
 
-        struct client_theme *theme = state->workspace_list->theme;
+        struct theme *theme = state->workspace_list->theme;
 
         client->is_focused = true;
 
@@ -824,7 +823,7 @@ void client_set_unfocused(const struct natwm_state *state,
                 return;
         }
 
-        struct client_theme *theme = state->workspace_list->theme;
+        struct theme *theme = state->workspace_list->theme;
 
         client->is_focused = false;
 
@@ -866,7 +865,7 @@ enum natwm_error client_update_hints(const struct natwm_state *state,
         }
 
         if (hints & FRAME_EXTENTS) {
-                struct client_theme *theme = state->workspace_list->theme;
+                struct theme *theme = state->workspace_list->theme;
                 uint32_t border_width
                         = client_get_active_border_width(theme, client);
 
@@ -891,57 +890,6 @@ enum natwm_error client_update_hints(const struct natwm_state *state,
         }
 
         return NO_ERROR;
-}
-
-enum natwm_error client_theme_create(const struct map *config_map,
-                                     struct client_theme **result)
-{
-        struct client_theme *theme = malloc(sizeof(struct client_theme));
-
-        if (theme == NULL) {
-                return MEMORY_ALLOCATION_ERROR;
-        }
-
-        enum natwm_error err = GENERIC_ERROR;
-
-        err = border_theme_from_config(config_map,
-                                       WINDOW_BORDER_WIDTH_CONFIG_STRING,
-                                       &theme->border_width);
-
-        if (err != NO_ERROR) {
-                goto handle_error;
-        }
-
-        err = color_theme_from_config(
-                config_map, WINDOW_BORDER_COLOR_CONFIG_STRING, &theme->color);
-
-        if (err != NO_ERROR) {
-                goto handle_error;
-        }
-
-        *result = theme;
-
-        return NO_ERROR;
-
-handle_error:
-        client_theme_destroy(theme);
-
-        LOG_ERROR(natwm_logger, "Failed to create client theme");
-
-        return INVALID_INPUT_ERROR;
-}
-
-void client_theme_destroy(struct client_theme *theme)
-{
-        if (theme->border_width != NULL) {
-                border_theme_destroy(theme->border_width);
-        }
-
-        if (theme->color != NULL) {
-                color_theme_destroy(theme->color);
-        }
-
-        free(theme);
 }
 
 void client_destroy(struct client *client)

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -81,6 +81,9 @@ void client_set_unfocused(const struct natwm_state *state,
                           struct client *client);
 enum natwm_error client_focus_window(struct natwm_state *state,
                                      xcb_window_t window);
+enum natwm_error client_send_window_to_workspace(struct natwm_state *state,
+                                                 xcb_window_t window,
+                                                 size_t index);
 enum natwm_error client_update_hints(const struct natwm_state *state,
                                      const struct client *client,
                                      enum client_hints hints);

--- a/src/core/client.h
+++ b/src/core/client.h
@@ -34,17 +34,6 @@ enum client_hints {
         CLIENT_HINTS_ALL = FRAME_EXTENTS | WM_ALLOWED_ACTIONS | WM_DESKTOP,
 };
 
-/**
- * This is the global theme for all clients.
- *
- * The values are user configurable and define the look and feel of the client
- * when it is rendered to the screen.
- */
-struct client_theme {
-        struct border_theme *border_width;
-        struct color_theme *color;
-};
-
 struct client {
         xcb_window_t window;
         xcb_rectangle_t rect;
@@ -73,11 +62,10 @@ enum natwm_error client_unmap_window(struct natwm_state *state,
                                      xcb_window_t window);
 enum natwm_error client_handle_destroy_notify(struct natwm_state *state,
                                               xcb_window_t window);
-uint16_t client_get_active_border_width(const struct client_theme *theme,
+uint16_t client_get_active_border_width(const struct theme *theme,
                                         const struct client *client);
-struct color_value *
-client_get_active_border_color(const struct client_theme *theme,
-                               const struct client *client);
+struct color_value *client_get_active_border_color(const struct theme *theme,
+                                                   const struct client *client);
 enum natwm_error client_unset_fullscreen(const struct natwm_state *state,
                                          struct client *client);
 enum natwm_error client_set_fullscreen(const struct natwm_state *state,
@@ -97,8 +85,4 @@ enum natwm_error client_update_hints(const struct natwm_state *state,
                                      const struct client *client,
                                      enum client_hints hints);
 
-enum natwm_error client_theme_create(const struct map *config_map,
-                                     struct client_theme **result);
-
-void client_theme_destroy(struct client_theme *theme);
 void client_destroy(struct client *client);

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -28,6 +28,11 @@ static enum natwm_error
 event_handle_client_message(struct natwm_state *state,
                             xcb_client_message_event_t *event)
 {
+        if (event->format != 32) {
+                // We currently only support format 32
+                return NO_ERROR;
+        }
+
         xcb_window_t window = event->window;
 
         if (event->type == state->ewmh->_NET_ACTIVE_WINDOW) {
@@ -37,6 +42,10 @@ event_handle_client_message(struct natwm_state *state,
 
                 return workspace_list_switch_to_workspace(state,
                                                           workspace_index);
+        } else if (event->type == state->ewmh->_NET_WM_DESKTOP) {
+                uint32_t workspace_index = event->data.data32[0];
+
+                LOG_INFO(natwm_logger, "Sending client to %u", workspace_index);
         } else if (event->type == state->ewmh->_NET_WM_STATE) {
                 xcb_atom_t state_atom = (event->data.data32[1] != NO_ERROR)
                         ? event->data.data32[1]

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -45,7 +45,7 @@ event_handle_client_message(struct natwm_state *state,
         } else if (event->type == state->ewmh->_NET_WM_DESKTOP) {
                 uint32_t workspace_index = event->data.data32[0];
 
-                LOG_INFO(natwm_logger, "Sending client to %u", workspace_index);
+                client_send_window_to_workspace(state, window, workspace_index);
         } else if (event->type == state->ewmh->_NET_WM_STATE) {
                 xcb_atom_t state_atom = (event->data.data32[1] != NO_ERROR)
                         ? event->data.data32[1]

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -45,7 +45,8 @@ event_handle_client_message(struct natwm_state *state,
         } else if (event->type == state->ewmh->_NET_WM_DESKTOP) {
                 uint32_t workspace_index = event->data.data32[0];
 
-                client_send_window_to_workspace(state, window, workspace_index);
+                return client_send_window_to_workspace(
+                        state, window, workspace_index);
         } else if (event->type == state->ewmh->_NET_WM_STATE) {
                 xcb_atom_t state_atom = (event->data.data32[1] != NO_ERROR)
                         ? event->data.data32[1]

--- a/src/core/monitor.c
+++ b/src/core/monitor.c
@@ -293,6 +293,10 @@ struct monitor *
 monitor_list_get_workspace_monitor(const struct monitor_list *monitor_list,
                                    const struct workspace *workspace)
 {
+        if (workspace == NULL) {
+                return NULL;
+        }
+
         LIST_FOR_EACH(monitor_list->monitors, monitor_item)
         {
                 struct monitor *monitor = (struct monitor *)monitor_item->data;

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -585,19 +585,6 @@ struct client *workspace_find_window_client(const struct workspace *workspace,
         return NULL;
 }
 
-bool workspace_index_does_exist(const struct workspace_list *list, size_t index)
-{
-        if (index > (list->count - 1)) {
-                return false;
-        }
-
-        if (list->workspaces[index] == NULL) {
-                return false;
-        }
-
-        return true;
-}
-
 struct workspace *workspace_list_get_focused(const struct workspace_list *list)
 {
         return list->workspaces[list->active_index];
@@ -606,7 +593,7 @@ struct workspace *workspace_list_get_focused(const struct workspace_list *list)
 struct workspace *
 workspace_list_get_workspace(const struct workspace_list *list, size_t index)
 {
-        if (!workspace_index_does_exist(list, index)) {
+        if (index > (list->count - 1)) {
                 return NULL;
         }
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -693,11 +693,11 @@ enum natwm_error workspace_list_send_to_workspace(struct natwm_state *state,
                 return NO_ERROR;
         }
 
-        struct workspace *current_workspace
+        struct workspace *client_workspace
                 = workspace_list_find_client_workspace(state->workspace_list,
                                                        client);
 
-        if (!current_workspace) {
+        if (!client_workspace) {
                 LOG_ERROR(natwm_logger,
                           "Failed to find current workspace when moving "
                           "client to new workspace");
@@ -709,7 +709,7 @@ enum natwm_error workspace_list_send_to_workspace(struct natwm_state *state,
 
         client_hide(state, client);
 
-        err = workspace_remove_client(state, current_workspace, client);
+        err = workspace_remove_client(state, client_workspace, client);
 
         if (err != NO_ERROR) {
                 LOG_ERROR(natwm_logger,

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -67,6 +67,13 @@ static void attach_to_monitors(struct monitor_list *monitor_list,
                 struct monitor *monitor = (struct monitor *)monitor_item->data;
                 struct workspace *workspace = workspace_list->workspaces[index];
 
+                if (workspace == NULL) {
+                        LOG_ERROR(natwm_logger,
+                                  "Failed to find workspace for monitor");
+
+                        return;
+                }
+
                 // Focus on the first monitor
                 if (index == 0) {
                         workspace_list->active_index = 0;
@@ -640,7 +647,7 @@ enum natwm_error workspace_list_switch_to_workspace(struct natwm_state *state,
 void workspace_list_destroy(struct workspace_list *workspace_list)
 {
         if (workspace_list->theme != NULL) {
-                client_theme_destroy(workspace_list->theme);
+                theme_destroy(workspace_list->theme);
         }
 
         map_destroy(workspace_list->client_map);

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -681,10 +681,10 @@ enum natwm_error workspace_list_send_to_workspace(struct natwm_state *state,
                 = workspace_list_get_workspace(state->workspace_list, index);
 
         if (!next_workspace) {
-                LOG_ERROR(natwm_logger,
-                          "Attempting to move window to non-existent "
-                          "workspace %u",
-                          index);
+                LOG_WARNING(natwm_logger,
+                            "Attempting to move window to non-existent "
+                            "workspace %u",
+                            index);
 
                 return INVALID_INPUT_ERROR;
         }

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -593,7 +593,7 @@ struct workspace *workspace_list_get_focused(const struct workspace_list *list)
 struct workspace *
 workspace_list_get_workspace(const struct workspace_list *list, size_t index)
 {
-        if (index > (list->count - 1)) {
+        if (index >= list->count) {
                 return NULL;
         }
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -530,6 +530,19 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
         return NO_ERROR;
 }
 
+bool workspace_index_does_exist(const struct natwm_state *state, size_t index)
+{
+        if (index > (state->workspace_list->count - 1)) {
+                return false;
+        }
+
+        if (state->workspace_list->workspaces[index] == NULL) {
+                return false;
+        }
+
+        return true;
+}
+
 enum natwm_error workspace_remove_client(struct natwm_state *state,
                                          struct workspace *workspace,
                                          struct client *client)
@@ -624,7 +637,7 @@ workspace_list_find_window_client(const struct workspace_list *list,
 enum natwm_error workspace_list_switch_to_workspace(struct natwm_state *state,
                                                     size_t workspace_index)
 {
-        if (workspace_index >= state->workspace_list->count) {
+        if (!workspace_index_does_exist(state, workspace_index)) {
                 LOG_WARNING(natwm_logger,
                             "Attempted to switch to non-existent workspace %u",
                             workspace_index);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -42,6 +42,7 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
 enum natwm_error workspace_remove_client(struct natwm_state *state,
                                          struct workspace *workspace,
                                          struct client *client);
+bool workspace_index_does_exist(const struct natwm_state *state, size_t index);
 struct client *workspace_find_window_client(const struct workspace *workspace,
                                             xcb_window_t window);
 void workspace_set_focused(const struct natwm_state *state,

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -74,5 +74,8 @@ workspace_list_find_window_client(const struct workspace_list *list,
                                   xcb_window_t window);
 enum natwm_error workspace_list_switch_to_workspace(struct natwm_state *state,
                                                     size_t workspace_index);
+enum natwm_error workspace_list_send_to_workspace(struct natwm_state *state,
+                                                  struct client *client,
+                                                  size_t index);
 void workspace_list_destroy(struct workspace_list *workspace_list);
 void workspace_destroy(struct workspace *workspace);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -10,6 +10,7 @@
 #include <common/error.h>
 #include <common/list.h>
 #include <common/map.h>
+#include <common/theme.h>
 
 #include "client.h"
 #include "state.h"
@@ -17,7 +18,7 @@
 struct workspace_list {
         size_t count;
         size_t active_index;
-        struct client_theme *theme;
+        struct theme *theme;
         struct map *client_map;
         struct workspace **workspaces;
 };

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -58,8 +58,6 @@ enum natwm_error workspace_unfocus_client(struct natwm_state *state,
                                           struct client *client);
 enum natwm_error workspace_change_monitor(struct natwm_state *state,
                                           struct workspace *workspace);
-bool workspace_list_index_does_exist(const struct workspace_list *list,
-                                     size_t index);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);
 struct workspace *
 workspace_list_get_workspace(const struct workspace_list *list, size_t index);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -42,7 +42,6 @@ enum natwm_error workspace_add_client(struct natwm_state *state,
 enum natwm_error workspace_remove_client(struct natwm_state *state,
                                          struct workspace *workspace,
                                          struct client *client);
-bool workspace_index_does_exist(const struct natwm_state *state, size_t index);
 struct client *workspace_find_window_client(const struct workspace *workspace,
                                             xcb_window_t window);
 void workspace_set_focused(const struct natwm_state *state,
@@ -59,7 +58,11 @@ enum natwm_error workspace_unfocus_client(struct natwm_state *state,
                                           struct client *client);
 enum natwm_error workspace_change_monitor(struct natwm_state *state,
                                           struct workspace *workspace);
+bool workspace_list_index_does_exist(const struct workspace_list *list,
+                                     size_t index);
 struct workspace *workspace_list_get_focused(const struct workspace_list *list);
+struct workspace *
+workspace_list_get_workspace(const struct workspace_list *list, size_t index);
 struct workspace *
 workspace_list_find_client_workspace(const struct workspace_list *list,
                                      const struct client *client);

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -14,6 +14,7 @@
 #include <common/constants.h>
 #include <common/logger.h>
 #include <common/map.h>
+#include <common/theme.h>
 #include <common/util.h>
 #include <core/client.h>
 #include <core/config/config.h>
@@ -381,8 +382,10 @@ int main(int argc, char **argv)
         //
         // TODO: Set defaults so we don't have a hard requirement on the user
         // settings these in their configuration
-        if (client_theme_create(state->config, &state->workspace_list->theme)
-            != NO_ERROR) {
+        state->workspace_list->theme = theme_create(state->config);
+
+        if (state->workspace_list->theme == NULL) {
+                LOG_INFO(natwm_logger, "Failed to set up theme");
                 goto free_and_error;
         }
 

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -385,7 +385,8 @@ int main(int argc, char **argv)
         state->workspace_list->theme = theme_create(state->config);
 
         if (state->workspace_list->theme == NULL) {
-                LOG_INFO(natwm_logger, "Failed to set up theme");
+                LOG_ERROR(natwm_logger, "Failed to initialize client theme");
+
                 goto free_and_error;
         }
 


### PR DESCRIPTION
This PR implements support for the `_NET_WM_DESKTOP` client message.

This will allow for moving a client from one workspace to another.

It supports moving client to non-visible workspace and visible workspaces