### PR TITLE
Fix/correctly handle abort

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -83,20 +83,3 @@ bool path_exists(const char *path)
 
         return true;
 }
-
-/**
- * Sleep for a spcified number of miliseconds
- */
-void millisecond_sleep(uint32_t miliseconds)
-{
-        struct timeval tv = {
-                0, // Seconds
-                (suseconds_t)(miliseconds * 1000L), // Microseconds
-        };
-
-        int ret = 0;
-
-        do {
-                ret = select(1, NULL, NULL, NULL, &tv);
-        } while ((ret == -1) && (errno == EINTR));
-}

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -26,7 +26,7 @@
 #include <core/workspace.h>
 
 #define STOPPED -1
-#define RUNNING 1
+#define RUNNING 0
 
 // Program status
 static volatile sig_atomic_t status = STOPPED;

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -169,8 +169,7 @@ static void *wm_event_loop(void *passed_state)
         int xcb_fd = xcb_get_file_descriptor(state->xcb);
 
         // If there hasn't been an X event in 25 milliseconds then we timeout
-        // this loop and check for any interuptions or errors before restarting
-        // the loop
+        // and check for any interuptions or errors
         struct timespec timeout = {
                 .tv_sec = 0,
                 .tv_nsec = 25000000, // 25 Milliseconds

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -143,7 +143,7 @@ static int root_window_subscribe(const struct natwm_state *state)
 
         xcb_flush(state->xcb);
 
-        if (error != NULL) {
+        if (error != XCB_NONE) {
                 // We will fail if there is already a window manager present
                 free(error);
 

--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -162,7 +162,7 @@ static void *wm_event_loop(void *passed_state)
                 LOG_ERROR(natwm_logger,
                           "Received invalid passed state to event loop");
 
-                return (void *)-1;
+                return (intptr_t *)-1;
         }
 
         fd_set fds;
@@ -214,14 +214,14 @@ static void *wm_event_loop(void *passed_state)
 
                         status = STOPPED;
 
-                        break;
+                        return (intptr_t *)-1;
                 }
         }
 
         // Event loop stopped disconnect from x
         LOG_INFO(natwm_logger, "Disconnected...");
 
-        return (void *)0;
+        return (intptr_t *)0;
 }
 
 static struct argument_options *parse_arguments(int argc, char **argv)


### PR DESCRIPTION
fixes #88 

This PR addresses a long standing issue which was that we were blocking while waiting for events from the X server. This broke signal handling since we would not recognize when an interruption happened until we received an X event.

This PR moves us to an approach which monitors the X file descriptor for changes, and if there is nothing to react to within 25MS we will check for any X server errors or interruptions.

This will allow in the future to also listen for reload signals when we implement them.