### PR TITLE
natwm/natwm: sys/signal.h -> signal.h

### DIFF
--- a/src/natwm/natwm.c
+++ b/src/natwm/natwm.c
@@ -4,10 +4,10 @@
 
 #include <getopt.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/select.h>
-#include <sys/signal.h>
 #include <unistd.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_util.h>


### PR DESCRIPTION
fixes: #93 

OSX cannot build when `signal.h` is replaced with `sys/signal.h`

Signed-off-by: Chris Frank <chris@cfrank.org>