### PR TITLE
core/events: Handle _NET_CLOSE_WINDOW

### DIFF
--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -37,6 +37,8 @@ event_handle_client_message(struct natwm_state *state,
 
         if (event->type == state->ewmh->_NET_ACTIVE_WINDOW) {
                 return client_focus_window(state, window);
+        } else if (event->type == state->ewmh->_NET_CLOSE_WINDOW) {
+                xcb_destroy_window(state->xcb, window);
         } else if (event->type == state->ewmh->_NET_CURRENT_DESKTOP) {
                 uint32_t workspace_index = event->data.data32[0];
 
@@ -83,15 +85,8 @@ event_handle_destroy_notify(struct natwm_state *state,
                             xcb_destroy_notify_event_t *event)
 {
         xcb_window_t window = event->window;
-        enum natwm_error err = client_handle_destroy_notify(state, window);
 
-        if (err != NO_ERROR) {
-                // A failure here would corrupt the integrity of the workspace
-                // list.
-                return err;
-        }
-
-        return NO_ERROR;
+        return client_handle_destroy_notify(state, window);
 }
 
 static enum natwm_error event_handle_map_request(struct natwm_state *state,

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -39,6 +39,8 @@ event_handle_client_message(struct natwm_state *state,
                 return client_focus_window(state, window);
         } else if (event->type == state->ewmh->_NET_CLOSE_WINDOW) {
                 xcb_destroy_window(state->xcb, window);
+
+                return NO_ERROR;
         } else if (event->type == state->ewmh->_NET_CURRENT_DESKTOP) {
                 uint32_t workspace_index = event->data.data32[0];
 

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -39,8 +39,6 @@ event_handle_client_message(struct natwm_state *state,
                 return client_focus_window(state, window);
         } else if (event->type == state->ewmh->_NET_CLOSE_WINDOW) {
                 xcb_destroy_window(state->xcb, window);
-
-                return NO_ERROR;
         } else if (event->type == state->ewmh->_NET_CURRENT_DESKTOP) {
                 uint32_t workspace_index = event->data.data32[0];
 


### PR DESCRIPTION
fixes #91 

When receiving a `_NET_CLOSE_WINDOW` we should attempt to destroy the window

Signed-off-by: Chris Frank <chris@cfrank.org>