### PR TITLE
core/client: Queue button index 1 events until after focus

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -401,8 +401,24 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
                 return RESOLUTION_FAILURE;
         }
 
+        // TODO: This will need some refactoring once we start handling more
+        // button press events
         if (event->state == XCB_NONE) {
-                return workspace_focus_client(state, workspace, client);
+                enum natwm_error err
+                        = workspace_focus_client(state, workspace, client);
+
+                if (err != NO_ERROR) {
+                        return err;
+                }
+
+                // For the focus event we queue the event, and once we have
+                // focused both the workspace (if needed) and the client we
+                // release the queued event and the client receives the event
+                // like normal
+                xcb_allow_events(
+                        state->xcb, XCB_ALLOW_REPLAY_POINTER, XCB_CURRENT_TIME);
+
+                return NO_ERROR;
         }
 
         return NO_ERROR;

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -28,7 +28,7 @@ struct mouse_binding {
 static const struct mouse_binding client_focus_event = {
         .pass_event = 1,
         .mask = DEFAULT_BUTTON_MASK,
-        .pointer_mode = XCB_GRAB_MODE_ASYNC,
+        .pointer_mode = XCB_GRAB_MODE_SYNC,
         .keyboard_mode = XCB_GRAB_MODE_ASYNC,
         .cursor = XCB_NONE,
         .button = XCB_BUTTON_INDEX_1,


### PR DESCRIPTION
fixes #92 

We need to first queue the button index 1 event and wait until we are
finished focusing the workspace (if needed) and the client. Once we have
done this we can release the event and the client window will receieve
the event like normal.

This fixes the bug where you first would need to click on a window, then
after focusing would need to perform the click again to have the client
register it.

Signed-off-by: Chris Frank <chris@cfrank.org>