### PR TITLE
Fix/toggleable modifiers

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(core STATIC
+    button.c
+    button.h
     client.c
     client.h
     config/config.c
@@ -15,8 +17,6 @@ add_library(core STATIC
     ewmh.h
     monitor.c
     monitor.h
-    mouse.c
-    mouse.h
     randr.c
     randr.h
     state.c

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(core
         xcb
         xcb-ewmh
         xcb-icccm
+        xcb-keysyms
         xcb-randr
         xcb-xinerama
 )

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -37,7 +37,7 @@ static uint16_t mask_from_keysym(xcb_key_symbols_t *symbols, xcb_keycode_t *modi
                                 if (*key == modifier) {
                                         free(keycodes);
 
-                                        return ((uint16_t)1 << i);
+                                        return (uint16_t)(1 << i);
                                 }
                         }
                 }

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -12,57 +12,57 @@
 
 #include "button.h"
 
-static uint16_t *resolve_modifier_masks(const struct button_modifiers *modifiers)
+static uint16_t *resolve_toggle_masks(const struct toggle_modifiers *modifiers)
 {
         int index = -1;
-        uint16_t *modifier_masks = malloc(sizeof(uint16_t) * 8);
+        uint16_t *masks = malloc(sizeof(uint16_t) * 8);
 
-        if (modifier_masks == NULL) {
+        if (masks == NULL) {
                 return NULL;
         }
 
         if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->caps_lock != XCB_NO_SYMBOL
             && modifiers->scroll_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index]
+                masks[++index]
                         = (modifiers->num_lock | modifiers->caps_lock | modifiers->scroll_lock);
         }
 
         if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->caps_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = (modifiers->num_lock | modifiers->caps_lock);
+                masks[++index] = (modifiers->num_lock | modifiers->caps_lock);
         }
 
         if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->scroll_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = (modifiers->num_lock | modifiers->scroll_lock);
+                masks[++index] = (modifiers->num_lock | modifiers->scroll_lock);
         }
 
         if (modifiers->caps_lock != XCB_NO_SYMBOL && modifiers->scroll_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = (modifiers->caps_lock | modifiers->scroll_lock);
+                masks[++index] = (modifiers->caps_lock | modifiers->scroll_lock);
         }
 
         if (modifiers->num_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = modifiers->num_lock;
+                masks[++index] = modifiers->num_lock;
         }
 
         if (modifiers->caps_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = modifiers->caps_lock;
+                masks[++index] = modifiers->caps_lock;
         }
 
         if (modifiers->scroll_lock != XCB_NO_SYMBOL) {
-                modifier_masks[++index] = modifiers->scroll_lock;
+                masks[++index] = modifiers->scroll_lock;
         }
 
-        modifier_masks[++index] = XCB_NO_SYMBOL;
+        masks[++index] = XCB_NO_SYMBOL;
 
-        return modifier_masks;
+        return masks;
 }
 
 // Heavily influenced from bspwm:
 // https://github.com/baskerville/bspwm/blob/master/src/pointer.c
 //
 // Given a xcb_keysym_t attempt to find and return the mod mask
-static uint16_t mask_from_keysym(xcb_key_symbols_t *symbols, xcb_keycode_t *modifiers,
-                                 uint8_t modifier_num, uint8_t keycodes_per_modifier,
-                                 xcb_keysym_t keysym)
+static uint16_t modifier_mask_from_keysym(xcb_key_symbols_t *symbols,
+                                          const xcb_keycode_t *modifiers, uint8_t modifier_num,
+                                          uint8_t keycodes_per_modifier, xcb_keysym_t keysym)
 {
         xcb_keycode_t *keycodes = xcb_key_symbols_get_keycode(symbols, keysym);
 
@@ -102,9 +102,9 @@ static uint16_t mask_from_keysym(xcb_key_symbols_t *symbols, xcb_keycode_t *modi
 // An example is when you are trying to focus on a window with caps lock active. This no longer
 // resolves as just a simple XCB_BUTTON_INDEX_1 event it is a XCB_BUTTON_INDEX_1 event with
 // the additional CAPS_LOCK modifier active.
-static struct button_modifiers *resolve_button_modifiers(xcb_connection_t *connection)
+static struct toggle_modifiers *resolve_toggle_modifiers(xcb_connection_t *connection)
 {
-        struct button_modifiers *modifiers = malloc(sizeof(struct button_modifiers));
+        struct toggle_modifiers *modifiers = malloc(sizeof(struct toggle_modifiers));
 
         if (modifiers == NULL) {
                 return NULL;
@@ -130,16 +130,10 @@ static struct button_modifiers *resolve_button_modifiers(xcb_connection_t *conne
                 return NULL;
         }
 
-        xcb_keycode_t *modifier_keycodes = xcb_get_modifier_mapping_keycodes(reply);
+        const xcb_keycode_t *modifier_keycodes = xcb_get_modifier_mapping_keycodes(reply);
 
         if (modifier_keycodes == NULL) {
-                free(modifiers);
-
-                xcb_key_symbols_free(symbols);
-
-                free(reply);
-
-                return NULL;
+                goto handle_error;
         }
 
         int modifier_num
@@ -148,42 +142,45 @@ static struct button_modifiers *resolve_button_modifiers(xcb_connection_t *conne
         // Usually (Mod1-Mod5, Shift, Control, Lock)
         assert(modifier_num >= 0 && modifier_num <= UINT8_MAX);
 
-        modifiers->num_lock = mask_from_keysym(symbols,
-                                               modifier_keycodes,
-                                               (uint8_t)modifier_num,
-                                               reply->keycodes_per_modifier,
-                                               NUM_LOCK_KEYSYM);
-        modifiers->caps_lock = mask_from_keysym(symbols,
-                                                modifier_keycodes,
-                                                (uint8_t)modifier_num,
-                                                reply->keycodes_per_modifier,
-                                                CAPS_LOCK_KEYSYM);
-        modifiers->scroll_lock = mask_from_keysym(symbols,
-                                                  modifier_keycodes,
-                                                  (uint8_t)modifier_num,
-                                                  reply->keycodes_per_modifier,
-                                                  SCROLL_LOCK_KEYSYM);
+        modifiers->num_lock = modifier_mask_from_keysym(symbols,
+                                                        modifier_keycodes,
+                                                        (uint8_t)modifier_num,
+                                                        reply->keycodes_per_modifier,
+                                                        NUM_LOCK_KEYSYM);
+        modifiers->caps_lock = modifier_mask_from_keysym(symbols,
+                                                         modifier_keycodes,
+                                                         (uint8_t)modifier_num,
+                                                         reply->keycodes_per_modifier,
+                                                         CAPS_LOCK_KEYSYM);
+        modifiers->scroll_lock = modifier_mask_from_keysym(symbols,
+                                                           modifier_keycodes,
+                                                           (uint8_t)modifier_num,
+                                                           reply->keycodes_per_modifier,
+                                                           SCROLL_LOCK_KEYSYM);
 
         if (modifiers->caps_lock == XCB_NO_SYMBOL) {
                 modifiers->caps_lock = XCB_MOD_MASK_LOCK;
         }
 
-        modifiers->modifier_masks = resolve_modifier_masks(modifiers);
+        modifiers->masks = resolve_toggle_masks(modifiers);
 
-        if (modifiers->modifier_masks == NULL) {
-                free(modifiers);
-
-                xcb_key_symbols_free(symbols);
-
-                free(reply);
-
-                return NULL;
+        if (modifiers->masks == NULL) {
+                goto handle_error;
         }
 
         xcb_key_symbols_free(symbols);
         free(reply);
 
         return modifiers;
+
+handle_error:
+        free(modifiers);
+
+        xcb_key_symbols_free(symbols);
+
+        free(reply);
+
+        return NULL;
 }
 
 struct button_state *button_state_create(xcb_connection_t *connection)
@@ -194,10 +191,11 @@ struct button_state *button_state_create(xcb_connection_t *connection)
                 return NULL;
         }
 
-        state->modifiers = resolve_button_modifiers(connection);
+        state->modifiers = resolve_toggle_modifiers(connection);
 
         if (state->modifiers == NULL) {
-                LOG_WARNING(natwm_logger, "Failed to resolve modifier keys! This may cause issues");
+                LOG_WARNING(natwm_logger,
+                            "Failed to resolve toggleable modifier keys! This may cause issues");
         }
 
         state->grabbed_client = NULL;
@@ -205,7 +203,7 @@ struct button_state *button_state_create(xcb_connection_t *connection)
         return state;
 }
 
-ATTR_INLINE uint16_t button_modifiers_get_clean_mask(const struct button_modifiers *modifiers,
+ATTR_INLINE uint16_t toggle_modifiers_get_clean_mask(const struct toggle_modifiers *modifiers,
                                                      uint16_t mask)
 {
         uint16_t modifier_mask
@@ -214,8 +212,8 @@ ATTR_INLINE uint16_t button_modifiers_get_clean_mask(const struct button_modifie
         return (uint16_t)(mask & ~(modifier_mask));
 }
 
-ATTR_INLINE void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
-                                     const struct button_binding *binding)
+void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
+                         const struct button_binding *binding)
 {
         xcb_grab_button(state->xcb,
                         binding->pass_event,
@@ -228,13 +226,13 @@ ATTR_INLINE void button_binding_grab(const struct natwm_state *state, xcb_window
                         binding->button,
                         binding->modifiers);
 
-        struct button_modifiers *modifiers = state->button_state->modifiers;
+        struct toggle_modifiers *modifiers = state->button_state->modifiers;
 
         if (modifiers == NULL) {
                 return;
         }
 
-        for (uint16_t *mask = modifiers->modifier_masks; *mask != XCB_NO_SYMBOL; mask++) {
+        for (uint16_t *mask = modifiers->masks; *mask != XCB_NO_SYMBOL; mask++) {
                 xcb_grab_button(state->xcb,
                                 binding->pass_event,
                                 window,
@@ -285,7 +283,7 @@ enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace
 void button_state_destroy(struct button_state *state)
 {
         if (state->modifiers != NULL) {
-                free(state->modifiers->modifier_masks);
+                free(state->modifiers->masks);
                 free(state->modifiers);
         }
 

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -4,10 +4,10 @@
 
 #include <xcb/xcb.h>
 
-#include "mouse.h"
+#include "button.h"
 
-void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
-                             const struct mouse_binding *binding)
+void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
+                       const struct button_binding *binding)
 {
         xcb_grab_button(connection,
                         binding->pass_event,
@@ -25,19 +25,20 @@ void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
 // The only mouse event which will not be initialized here is the "click to
 // focus" event which needs to be created or destroyed based on the client
 // focus
-void mouse_initialize_client_listeners(const struct natwm_state *state, const struct client *client)
+void button_initialize_client_listeners(const struct natwm_state *state,
+                                        const struct client *client)
 {
-        for (size_t i = 0; i < MOUSE_EVENTS_NUM; ++i) {
-                struct mouse_binding binding = mouse_events[i];
+        for (size_t i = 0; i < BUTTON_EVENTS_NUM; ++i) {
+                struct button_binding binding = button_events[i];
 
-                mouse_event_grab_button(state->xcb, client->window, &binding);
+                button_event_grab(state->xcb, client->window, &binding);
         };
 
         xcb_flush(state->xcb);
 }
 
-enum natwm_error mouse_handle_focus(struct natwm_state *state, struct workspace *workspace,
-                                    struct client *client)
+enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace *workspace,
+                                     struct client *client)
 {
         enum natwm_error err = workspace_focus_client(state, workspace, client);
 

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -26,44 +26,45 @@
 // xcb_grab_button
 static uint16_t *resolve_toggle_masks(const struct toggle_modifiers *modifiers)
 {
-        int index = -1;
         uint16_t *masks = malloc(sizeof(uint16_t) * 8);
 
         if (masks == NULL) {
                 return NULL;
         }
 
-        if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->caps_lock != XCB_NO_SYMBOL
-            && modifiers->scroll_lock != XCB_NO_SYMBOL) {
+        int index = -1;
+
+        if (modifiers->num_lock != XCB_NONE && modifiers->caps_lock != XCB_NONE
+            && modifiers->scroll_lock != XCB_NONE) {
                 masks[++index]
                         = (modifiers->num_lock | modifiers->caps_lock | modifiers->scroll_lock);
         }
 
-        if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->caps_lock != XCB_NO_SYMBOL) {
+        if (modifiers->num_lock != XCB_NONE && modifiers->caps_lock != XCB_NONE) {
                 masks[++index] = (modifiers->num_lock | modifiers->caps_lock);
         }
 
-        if (modifiers->num_lock != XCB_NO_SYMBOL && modifiers->scroll_lock != XCB_NO_SYMBOL) {
+        if (modifiers->num_lock != XCB_NONE && modifiers->scroll_lock != XCB_NONE) {
                 masks[++index] = (modifiers->num_lock | modifiers->scroll_lock);
         }
 
-        if (modifiers->caps_lock != XCB_NO_SYMBOL && modifiers->scroll_lock != XCB_NO_SYMBOL) {
+        if (modifiers->caps_lock != XCB_NONE && modifiers->scroll_lock != XCB_NONE) {
                 masks[++index] = (modifiers->caps_lock | modifiers->scroll_lock);
         }
 
-        if (modifiers->num_lock != XCB_NO_SYMBOL) {
+        if (modifiers->num_lock != XCB_NONE) {
                 masks[++index] = modifiers->num_lock;
         }
 
-        if (modifiers->caps_lock != XCB_NO_SYMBOL) {
+        if (modifiers->caps_lock != XCB_NONE) {
                 masks[++index] = modifiers->caps_lock;
         }
 
-        if (modifiers->scroll_lock != XCB_NO_SYMBOL) {
+        if (modifiers->scroll_lock != XCB_NONE) {
                 masks[++index] = modifiers->scroll_lock;
         }
 
-        masks[++index] = XCB_NO_SYMBOL;
+        masks[++index] = XCB_NONE;
 
         return masks;
 }
@@ -86,11 +87,11 @@ static uint16_t modifier_mask_from_keysym(xcb_key_symbols_t *symbols,
                 for (uint8_t j = 0; j < keycodes_per_modifier; ++j) {
                         xcb_keycode_t modifier = modifiers[i * keycodes_per_modifier + j];
 
-                        if (modifier == XCB_NO_SYMBOL) {
+                        if (modifier == XCB_NONE) {
                                 continue;
                         }
 
-                        for (xcb_keycode_t *key = keycodes; *key != XCB_NO_SYMBOL; key++) {
+                        for (xcb_keycode_t *key = keycodes; *key != XCB_NONE; key++) {
                                 if (*key == modifier) {
                                         free(keycodes);
 
@@ -181,7 +182,7 @@ static struct toggle_modifiers *resolve_toggle_modifiers(xcb_connection_t *conne
                                                            reply->keycodes_per_modifier,
                                                            SCROLL_LOCK_KEYSYM);
 
-        if (modifiers->caps_lock == XCB_NO_SYMBOL) {
+        if (modifiers->caps_lock == XCB_NONE) {
                 modifiers->caps_lock = XCB_MOD_MASK_LOCK;
         }
 
@@ -260,7 +261,7 @@ void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
                 return;
         }
 
-        for (uint16_t *mask = modifiers->masks; *mask != XCB_NO_SYMBOL; mask++) {
+        for (uint16_t *mask = modifiers->masks; *mask != XCB_NONE; mask++) {
                 xcb_grab_button(state->xcb,
                                 binding->pass_event,
                                 window,

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -7,6 +7,7 @@
 #include <xcb/xcb.h>
 #include <xcb/xcb_keysyms.h>
 
+#include <common/constants.h>
 #include <common/logger.h>
 
 #include "button.h"
@@ -146,6 +147,15 @@ struct button_state *button_state_create(xcb_connection_t *connection)
         state->grabbed_client = NULL;
 
         return state;
+}
+
+ATTR_INLINE uint16_t button_modifiers_get_clean_mask(const struct button_modifiers *modifiers,
+                                                     uint16_t mask)
+{
+        uint16_t modifier_mask
+                = (modifiers->num_lock | modifiers->caps_lock | modifiers->scroll_lock);
+
+        return (uint16_t)(mask & ~(modifier_mask));
 }
 
 void button_event_grab(xcb_connection_t *connection, xcb_window_t window,

--- a/src/core/button.c
+++ b/src/core/button.c
@@ -2,9 +2,149 @@
 // Licensed under BSD-3-Clause
 // Refer to the license.txt file included in the root of the project
 
+#include <assert.h>
+#include <stdlib.h>
 #include <xcb/xcb.h>
+#include <xcb/xcb_keysyms.h>
+
+#include <common/logger.h>
 
 #include "button.h"
+
+// Heavily influenced from bspwm:
+// https://github.com/baskerville/bspwm/blob/master/src/pointer.c
+//
+// Given a xcb_keysym_t attempt to find and return the mod mask
+static uint16_t mask_from_keysym(xcb_key_symbols_t *symbols, xcb_keycode_t *modifiers,
+                                 uint16_t modifier_length, uint8_t keycodes_per_modifier,
+                                 xcb_keysym_t keysym)
+{
+        uint16_t result = 0;
+        xcb_keycode_t *keycodes = xcb_key_symbols_get_keycode(symbols, keysym);
+
+        if (keycodes == NULL) {
+                return result;
+        }
+
+        for (uint16_t i = 0; i < modifier_length; ++i) {
+                for (uint8_t j = 0; j < keycodes_per_modifier; ++j) {
+                        xcb_keycode_t modifier = modifiers[i * keycodes_per_modifier + j];
+
+                        if (modifier == XCB_NO_SYMBOL) {
+                                continue;
+                        }
+
+                        for (xcb_keycode_t *key = keycodes; *key != XCB_NO_SYMBOL; key++) {
+                                if (*key == modifier) {
+                                        result |= (uint16_t)(1 << i);
+                                }
+                        }
+                }
+        }
+
+        free(keycodes);
+
+        return result;
+}
+
+// Heavily influenced from bspwm:
+// https://github.com/baskerville/bspwm/blob/master/src/pointer.c
+//
+// We need to find the modifier mask for our modifier keys. This will allow us to correctly set
+// up button handlers in the future.
+//
+// An example is when you are trying to focus on a window with caps lock active. This no longer
+// resolves as just a simple XCB_BUTTON_INDEX_1 event it is a XCB_BUTTON_INDEX_1 event with
+// the additional CAPS_LOCK modifier active.
+static struct button_modifiers *resolve_button_modifiers(xcb_connection_t *connection)
+{
+        struct button_modifiers *modifiers = malloc(sizeof(struct button_modifiers));
+
+        if (modifiers == NULL) {
+                return NULL;
+        }
+
+        xcb_key_symbols_t *symbols = xcb_key_symbols_alloc(connection);
+
+        if (symbols == NULL) {
+                free(modifiers);
+
+                return NULL;
+        }
+
+        xcb_get_modifier_mapping_cookie_t cookie = xcb_get_modifier_mapping(connection);
+        xcb_get_modifier_mapping_reply_t *reply
+                = xcb_get_modifier_mapping_reply(connection, cookie, NULL);
+
+        if (reply == NULL || reply->keycodes_per_modifier < 1) {
+                free(modifiers);
+
+                xcb_key_symbols_free(symbols);
+
+                return NULL;
+        }
+
+        xcb_keycode_t *modifier_keycodes = xcb_get_modifier_mapping_keycodes(reply);
+
+        if (modifier_keycodes == NULL) {
+                free(modifiers);
+
+                xcb_key_symbols_free(symbols);
+
+                free(reply);
+
+                return NULL;
+        }
+
+        int modifier_length
+                = xcb_get_modifier_mapping_keycodes_length(reply) / reply->keycodes_per_modifier;
+
+        assert(modifier_length >= 0 && modifier_length <= UINT16_MAX);
+
+        modifiers->num_lock = mask_from_keysym(symbols,
+                                               modifier_keycodes,
+                                               (uint16_t)modifier_length,
+                                               reply->keycodes_per_modifier,
+                                               NUM_LOCK_KEYSYM);
+        modifiers->caps_lock = mask_from_keysym(symbols,
+                                                modifier_keycodes,
+                                                (uint16_t)modifier_length,
+                                                reply->keycodes_per_modifier,
+                                                CAPS_LOCK_KEYSYM);
+        modifiers->scroll_lock = mask_from_keysym(symbols,
+                                                  modifier_keycodes,
+                                                  (uint16_t)modifier_length,
+                                                  reply->keycodes_per_modifier,
+                                                  SCROLL_LOCK_KEYSYM);
+
+        if (modifiers->caps_lock == XCB_NO_SYMBOL) {
+                modifiers->caps_lock = XCB_MOD_MASK_LOCK;
+        }
+
+        xcb_key_symbols_free(symbols);
+        free(reply);
+
+        return modifiers;
+}
+
+struct button_state *button_state_create(xcb_connection_t *connection)
+{
+        struct button_state *state = malloc(sizeof(struct button_state));
+
+        if (state == NULL) {
+                return NULL;
+        }
+
+        state->modifiers = resolve_button_modifiers(connection);
+
+        if (state->modifiers == NULL) {
+                LOG_WARNING(natwm_logger, "Failed to resolve modifier keys! This may cause issues");
+        }
+
+        state->grabbed_client = NULL;
+
+        return state;
+}
 
 void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
                        const struct button_binding *binding)
@@ -53,4 +193,13 @@ enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace
         xcb_allow_events(state->xcb, XCB_ALLOW_REPLAY_POINTER, XCB_CURRENT_TIME);
 
         return NO_ERROR;
+}
+
+void button_state_destroy(struct button_state *state)
+{
+        if (state->modifiers != NULL) {
+                free(state->modifiers);
+        }
+
+        free(state);
 }

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -37,6 +37,7 @@ struct button_modifiers {
         uint16_t num_lock;
         uint16_t caps_lock;
         uint16_t scroll_lock;
+        uint16_t *modifier_masks;
 };
 
 struct button_state {
@@ -68,9 +69,9 @@ static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
 
 struct button_state *button_state_create(xcb_connection_t *connection);
 uint16_t button_modifiers_get_clean_mask(const struct button_modifiers *modifiers, uint16_t mask);
-void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
-                       const struct button_binding *binding);
 
+void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
+                         const struct button_binding *binding);
 void button_initialize_client_listeners(const struct natwm_state *state,
                                         const struct client *client);
 

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -33,15 +33,15 @@ struct button_binding {
         uint16_t modifiers;
 };
 
-struct button_modifiers {
+struct toggle_modifiers {
         uint16_t num_lock;
         uint16_t caps_lock;
         uint16_t scroll_lock;
-        uint16_t *modifier_masks;
+        uint16_t *masks;
 };
 
 struct button_state {
-        struct button_modifiers *modifiers;
+        struct toggle_modifiers *modifiers;
         struct client *grabbed_client;
 };
 
@@ -68,7 +68,8 @@ static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
 };
 
 struct button_state *button_state_create(xcb_connection_t *connection);
-uint16_t button_modifiers_get_clean_mask(const struct button_modifiers *modifiers, uint16_t mask);
+
+uint16_t toggle_modifiers_get_clean_mask(const struct toggle_modifiers *modifiers, uint16_t mask);
 
 void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
                          const struct button_binding *binding);

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -17,6 +17,12 @@
 
 #define DEFAULT_BUTTON_MASK XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE
 
+// Toggleable keys
+// https://cgit.freedesktop.org/xorg/proto/x11proto/tree/keysymdef.h
+#define NUM_LOCK_KEYSYM 0xff7f
+#define CAPS_LOCK_KEYSYM 0xffe5
+#define SCROLL_LOCK_KEYSYM 0xff14
+
 struct button_binding {
         uint8_t pass_event;
         uint16_t mask;
@@ -25,6 +31,17 @@ struct button_binding {
         xcb_cursor_t cursor;
         uint8_t button;
         uint16_t modifiers;
+};
+
+struct button_modifiers {
+        uint16_t num_lock;
+        uint16_t caps_lock;
+        uint16_t scroll_lock;
+};
+
+struct button_state {
+        struct button_modifiers *modifiers;
+        struct client *grabbed_client;
 };
 
 static const struct button_binding client_focus_event = {
@@ -49,6 +66,7 @@ static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
         },
 };
 
+struct button_state *button_state_create(xcb_connection_t *connection);
 void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
                        const struct button_binding *binding);
 
@@ -57,3 +75,5 @@ void button_initialize_client_listeners(const struct natwm_state *state,
 
 enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace *workspace,
                                      struct client *client);
+
+void button_state_destroy(struct button_state *state);

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -64,12 +64,10 @@ static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
 struct button_state *button_state_create(xcb_connection_t *connection);
 
 uint16_t toggle_modifiers_get_clean_mask(const struct toggle_modifiers *modifiers, uint16_t mask);
-
 void button_binding_grab(const struct natwm_state *state, xcb_window_t window,
                          const struct button_binding *binding);
 void button_initialize_client_listeners(const struct natwm_state *state,
                                         const struct client *client);
-
 enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace *workspace,
                                      struct client *client);
 

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -17,12 +17,6 @@
 
 #define DEFAULT_BUTTON_MASK XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE
 
-// Toggleable keys
-// https://cgit.freedesktop.org/xorg/proto/x11proto/tree/keysymdef.h
-#define NUM_LOCK_KEYSYM 0xff7f
-#define CAPS_LOCK_KEYSYM 0xffe5
-#define SCROLL_LOCK_KEYSYM 0xff14
-
 struct button_binding {
         uint8_t pass_event;
         uint16_t mask;

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -67,6 +67,7 @@ static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
 };
 
 struct button_state *button_state_create(xcb_connection_t *connection);
+uint16_t button_modifiers_get_clean_mask(const struct button_modifiers *modifiers, uint16_t mask);
 void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
                        const struct button_binding *binding);
 

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -13,11 +13,11 @@
 #include "state.h"
 #include "workspace.h"
 
-#define MOUSE_EVENTS_NUM 1
+#define BUTTON_EVENTS_NUM 1
 
 #define DEFAULT_BUTTON_MASK XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE
 
-struct mouse_binding {
+struct button_binding {
         uint8_t pass_event;
         uint16_t mask;
         uint8_t pointer_mode;
@@ -27,9 +27,9 @@ struct mouse_binding {
         uint16_t modifiers;
 };
 
-static const struct mouse_binding client_focus_event = {
+static const struct button_binding client_focus_event = {
         .pass_event = 1,
-        .mask = DEFAULT_BUTTON_MASK,
+        .mask = XCB_EVENT_MASK_BUTTON_PRESS,
         .pointer_mode = XCB_GRAB_MODE_SYNC,
         .keyboard_mode = XCB_GRAB_MODE_ASYNC,
         .cursor = XCB_NONE,
@@ -37,7 +37,7 @@ static const struct mouse_binding client_focus_event = {
         .modifiers = XCB_NONE,
 };
 
-static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
+static const struct button_binding button_events[BUTTON_EVENTS_NUM] = {
         {
                 .pass_event = 1,
                 .mask = DEFAULT_BUTTON_MASK,
@@ -49,11 +49,11 @@ static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
         },
 };
 
-void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
-                             const struct mouse_binding *binding);
+void button_event_grab(xcb_connection_t *connection, xcb_window_t window,
+                       const struct button_binding *binding);
 
-void mouse_initialize_client_listeners(const struct natwm_state *state,
-                                       const struct client *client);
+void button_initialize_client_listeners(const struct natwm_state *state,
+                                        const struct client *client);
 
-enum natwm_error mouse_handle_focus(struct natwm_state *state, struct workspace *workspace,
-                                    struct client *client);
+enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace *workspace,
+                                     struct client *client);

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -380,25 +380,12 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
                 return RESOLUTION_FAILURE;
         }
 
-        // TODO: This will need some refactoring once we start handling more
-        // button press events
-        if (event->state == XCB_NONE) {
-                enum natwm_error err = workspace_focus_client(state, workspace, client);
-
-                if (err != NO_ERROR) {
-                        return err;
-                }
-
-                // For the focus event we queue the event, and once we have
-                // focused both the workspace (if needed) and the client we
-                // release the queued event and the client receives the event
-                // like normal
-                xcb_allow_events(state->xcb, XCB_ALLOW_REPLAY_POINTER, XCB_CURRENT_TIME);
-
+        switch (event->state) {
+        case XCB_NONE:
+                return mouse_handle_focus(state, workspace, client);
+        default:
                 return NO_ERROR;
         }
-
-        return NO_ERROR;
 }
 
 enum natwm_error client_configure_window(struct natwm_state *state,

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -769,10 +769,7 @@ void client_set_focused(struct natwm_state *state, struct client *client)
 
         // Now that we have focused the client, there is no need for "click to
         // focus" so we can remove the button grab
-        xcb_ungrab_button(state->xcb,
-                          client_focus_event.button,
-                          client->window,
-                          client_focus_event.modifiers);
+        xcb_ungrab_button(state->xcb, client_focus_event.button, client->window, XCB_MOD_MASK_ANY);
 
         uint16_t previous_border_width = theme->border_width->unfocused;
 
@@ -797,7 +794,7 @@ void client_set_unfocused(const struct natwm_state *state, struct client *client
 
         // When a client is unfocused we need to grab the mouse button required
         // for "click to focus"
-        button_event_grab(state->xcb, client->window, &client_focus_event);
+        button_binding_grab(state, client->window, &client_focus_event);
 
         update_theme(state, client, theme->border_width->focused);
 }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -383,6 +383,10 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
         switch (event->state) {
         case XCB_NONE:
                 return mouse_handle_focus(state, workspace, client);
+        case XCB_BUTTON_MASK_1:
+                natwm_state_set_moving_window(state, client->window);
+
+                return NO_ERROR;
         default:
                 return NO_ERROR;
         }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -380,7 +380,7 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
                 return RESOLUTION_FAILURE;
         }
 
-        switch (event->state) {
+        switch (button_modifiers_get_clean_mask(state->button_state->modifiers, event->state)) {
         case XCB_NONE:
                 return button_handle_focus(state, workspace, client);
         default:

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -8,10 +8,10 @@
 #include <common/constants.h>
 #include <common/logger.h>
 
+#include "button.h"
 #include "client.h"
 #include "ewmh.h"
 #include "monitor.h"
-#include "mouse.h"
 #include "workspace.h"
 
 static void handle_configure_request(xcb_connection_t *connection,
@@ -327,7 +327,7 @@ struct client *client_register_window(struct natwm_state *state, xcb_window_t wi
         client->rect = client_initialize_rect(client, workspace_monitor);
 
         // Listen for button events
-        mouse_initialize_client_listeners(state, client);
+        button_initialize_client_listeners(state, client);
 
         xcb_change_save_set(state->xcb, XCB_SET_MODE_INSERT, client->window);
 
@@ -382,7 +382,7 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
 
         switch (event->state) {
         case XCB_NONE:
-                return mouse_handle_focus(state, workspace, client);
+                return button_handle_focus(state, workspace, client);
         default:
                 return NO_ERROR;
         }
@@ -797,7 +797,7 @@ void client_set_unfocused(const struct natwm_state *state, struct client *client
 
         // When a client is unfocused we need to grab the mouse button required
         // for "click to focus"
-        mouse_event_grab_button(state->xcb, client->window, &client_focus_event);
+        button_event_grab(state->xcb, client->window, &client_focus_event);
 
         update_theme(state, client, theme->border_width->focused);
 }

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -380,7 +380,7 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
                 return RESOLUTION_FAILURE;
         }
 
-        switch (button_modifiers_get_clean_mask(state->button_state->modifiers, event->state)) {
+        switch (toggle_modifiers_get_clean_mask(state->button_state->modifiers, event->state)) {
         case XCB_NONE:
                 return button_handle_focus(state, workspace, client);
         default:

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -383,10 +383,6 @@ enum natwm_error client_handle_button_press(struct natwm_state *state,
         switch (event->state) {
         case XCB_NONE:
                 return mouse_handle_focus(state, workspace, client);
-        case XCB_BUTTON_MASK_1:
-                natwm_state_set_moving_window(state, client->window);
-
-                return NO_ERROR;
         default:
                 return NO_ERROR;
         }

--- a/src/core/events/event.c
+++ b/src/core/events/event.c
@@ -9,10 +9,10 @@
 #include <common/constants.h>
 #include <common/logger.h>
 
+#include <core/button.h>
 #include <core/client.h>
 #include <core/ewmh.h>
 #include <core/monitor.h>
-#include <core/mouse.h>
 
 #include "event.h"
 #include "randr-event.h"

--- a/src/core/mouse.c
+++ b/src/core/mouse.c
@@ -35,3 +35,21 @@ void mouse_initialize_client_listeners(const struct natwm_state *state, const st
 
         xcb_flush(state->xcb);
 }
+
+enum natwm_error mouse_handle_focus(struct natwm_state *state, struct workspace *workspace,
+                                    struct client *client)
+{
+        enum natwm_error err = workspace_focus_client(state, workspace, client);
+
+        if (err != NO_ERROR) {
+                return err;
+        }
+
+        // For the focus event we queue the event, and once we have
+        // focused both the workspace (if needed) and the client we
+        // release the queued event and the client receives the event
+        // like normal
+        xcb_allow_events(state->xcb, XCB_ALLOW_REPLAY_POINTER, XCB_CURRENT_TIME);
+
+        return NO_ERROR;
+}

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <xcb/xproto.h>
 
-#include <common/constants.h>
+#include <common/error.h>
 
 #include "client.h"
 #include "state.h"

--- a/src/core/mouse.h
+++ b/src/core/mouse.h
@@ -7,8 +7,11 @@
 #include <stdint.h>
 #include <xcb/xproto.h>
 
+#include <common/constants.h>
+
 #include "client.h"
 #include "state.h"
+#include "workspace.h"
 
 #define MOUSE_EVENTS_NUM 1
 
@@ -36,7 +39,7 @@ static const struct mouse_binding client_focus_event = {
 
 static const struct mouse_binding mouse_events[MOUSE_EVENTS_NUM] = {
         {
-                .pass_event = 0,
+                .pass_event = 1,
                 .mask = DEFAULT_BUTTON_MASK,
                 .pointer_mode = XCB_GRAB_MODE_ASYNC,
                 .keyboard_mode = XCB_GRAB_MODE_ASYNC,
@@ -51,3 +54,6 @@ void mouse_event_grab_button(xcb_connection_t *connection, xcb_window_t window,
 
 void mouse_initialize_client_listeners(const struct natwm_state *state,
                                        const struct client *client);
+
+enum natwm_error mouse_handle_focus(struct natwm_state *state, struct workspace *workspace,
+                                    struct client *client);

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included in the root of the project
 
 #include "state.h"
+#include "button.h"
 #include "config/config.h"
 #include "ewmh.h"
 #include "monitor.h"
@@ -20,6 +21,7 @@ struct natwm_state *natwm_state_create(void)
         state->xcb = NULL;
         state->ewmh = NULL;
         state->screen = NULL;
+        state->button_state = NULL;
         state->monitor_list = NULL;
         state->workspace_list = NULL;
         state->config = NULL;
@@ -58,6 +60,9 @@ void natwm_state_destroy(struct natwm_state *state)
                 return;
         }
 
+        if (state->button_state != NULL) {
+                button_state_destroy(state->button_state);
+        }
         if (state->workspace_list != NULL) {
                 workspace_list_destroy(state->workspace_list);
         }

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -63,6 +63,7 @@ void natwm_state_destroy(struct natwm_state *state)
         if (state->button_state != NULL) {
                 button_state_destroy(state->button_state);
         }
+
         if (state->workspace_list != NULL) {
                 workspace_list_destroy(state->workspace_list);
         }

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -20,6 +20,7 @@ struct natwm_state *natwm_state_create(void)
         state->xcb = NULL;
         state->ewmh = NULL;
         state->screen = NULL;
+        state->actively_moving_window = XCB_NONE;
         state->monitor_list = NULL;
         state->workspace_list = NULL;
         state->config = NULL;
@@ -48,6 +49,15 @@ void natwm_state_update_config(struct natwm_state *state, const struct map *new_
         natwm_state_lock(state);
 
         state->config = new_config;
+
+        natwm_state_unlock(state);
+}
+
+void natwm_state_set_moving_window(struct natwm_state *state, xcb_window_t window)
+{
+        natwm_state_lock(state);
+
+        state->actively_moving_window = window;
 
         natwm_state_unlock(state);
 }

--- a/src/core/state.c
+++ b/src/core/state.c
@@ -20,7 +20,6 @@ struct natwm_state *natwm_state_create(void)
         state->xcb = NULL;
         state->ewmh = NULL;
         state->screen = NULL;
-        state->actively_moving_window = XCB_NONE;
         state->monitor_list = NULL;
         state->workspace_list = NULL;
         state->config = NULL;
@@ -49,15 +48,6 @@ void natwm_state_update_config(struct natwm_state *state, const struct map *new_
         natwm_state_lock(state);
 
         state->config = new_config;
-
-        natwm_state_unlock(state);
-}
-
-void natwm_state_set_moving_window(struct natwm_state *state, xcb_window_t window)
-{
-        natwm_state_lock(state);
-
-        state->actively_moving_window = window;
 
         natwm_state_unlock(state);
 }

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -12,6 +12,7 @@
 #include <common/map.h>
 
 // Forward declare needed types
+struct button_state;
 struct monitor_list;
 struct workspace_list;
 
@@ -20,6 +21,7 @@ struct natwm_state {
         xcb_connection_t *xcb;
         xcb_ewmh_connection_t *ewmh;
         xcb_screen_t *screen;
+        struct button_state *button_state;
         struct monitor_list *monitor_list;
         struct workspace_list *workspace_list;
         const struct map *config;

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -20,7 +20,6 @@ struct natwm_state {
         xcb_connection_t *xcb;
         xcb_ewmh_connection_t *ewmh;
         xcb_screen_t *screen;
-        xcb_window_t actively_moving_window;
         struct monitor_list *monitor_list;
         struct workspace_list *workspace_list;
         const struct map *config;

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -20,6 +20,7 @@ struct natwm_state {
         xcb_connection_t *xcb;
         xcb_ewmh_connection_t *ewmh;
         xcb_screen_t *screen;
+        xcb_window_t actively_moving_window;
         struct monitor_list *monitor_list;
         struct workspace_list *workspace_list;
         const struct map *config;
@@ -31,4 +32,5 @@ struct natwm_state *natwm_state_create(void);
 void natwm_state_lock(struct natwm_state *state);
 void natwm_state_unlock(struct natwm_state *state);
 void natwm_state_update_config(struct natwm_state *state, const struct map *new_config);
+void natwm_state_set_moving_window(struct natwm_state *state, xcb_window_t window);
 void natwm_state_destroy(struct natwm_state *state);


### PR DESCRIPTION
fixes #100 

In order to account for toggle-able modifiers (caps lock, scroll lock, etc.) we need to first find the masks for those modifiers and then grab events for all combinations of event modifier | toggle0able modifier.

This PR adds the above functionality and fixes the issue where when caps lock (and other toggle-able modifiers) were active all button grabs were broken.