### PR TITLE
Fix/multi monitor dragging

### DIFF
--- a/src/core/button.c
+++ b/src/core/button.c
@@ -4,7 +4,6 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include <xcb/xcb.h>
 #include <xcb/xcb_keysyms.h>
 
 #include <common/constants.h>
@@ -326,7 +325,7 @@ enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace
 }
 
 enum natwm_error button_handle_grab(struct natwm_state *state, xcb_button_press_event_t *event,
-                                    struct client *client)
+                                    xcb_rectangle_t *monitor_rect, struct client *client)
 {
         if (!event->same_screen) {
                 LOG_ERROR(natwm_logger,
@@ -344,6 +343,7 @@ enum natwm_error button_handle_grab(struct natwm_state *state, xcb_button_press_
         natwm_state_lock(state);
 
         state->button_state->grabbed_client = client;
+        state->button_state->monitor_rect = monitor_rect;
         state->button_state->start_x = event->event_x;
         state->button_state->start_y = event->event_y;
 
@@ -381,6 +381,7 @@ enum natwm_error button_handle_ungrab(struct natwm_state *state)
         natwm_state_lock(state);
 
         state->button_state->grabbed_client = NULL;
+        state->button_state->monitor_rect = NULL;
         state->button_state->start_x = 0;
         state->button_state->start_y = 0;
 

--- a/src/core/button.h
+++ b/src/core/button.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <xcb/xcb.h>
 #include <xcb/xproto.h>
 
 #include <common/error.h>
@@ -37,6 +38,7 @@ struct toggle_modifiers {
 struct button_state {
         struct toggle_modifiers *modifiers;
         struct client *grabbed_client;
+        xcb_rectangle_t *monitor_rect;
         int16_t start_x;
         int16_t start_y;
 };
@@ -75,7 +77,7 @@ void button_initialize_client_listeners(const struct natwm_state *state,
 enum natwm_error button_handle_focus(struct natwm_state *state, struct workspace *workspace,
                                      struct client *client);
 enum natwm_error button_handle_grab(struct natwm_state *state, xcb_button_press_event_t *event,
-                                    struct client *client);
+                                    xcb_rectangle_t *monitor_rect, struct client *client);
 enum natwm_error button_handle_motion(struct natwm_state *state, int16_t x, int16_t y);
 enum natwm_error button_handle_ungrab(struct natwm_state *state);
 

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -577,9 +577,9 @@ enum natwm_error client_handle_drag(const struct natwm_state *state, struct clie
         client->rect.y = (int16_t)(client->rect.y + y);
 
         uint16_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y;
-        int32_t values[] = {
-                (int32_t)client->rect.x + state->button_state->monitor_rect->x,
-                (int32_t)client->rect.y + state->button_state->monitor_rect->y,
+        uint32_t values[] = {
+                (uint32_t)(client->rect.x + state->button_state->monitor_rect->x),
+                (uint32_t)(client->rect.y + state->button_state->monitor_rect->y),
         };
 
         xcb_configure_window(state->xcb, client->window, mask, values);


### PR DESCRIPTION
fixes #108 

Previously we weren't taking into account the monitor rect when dragging a window. This looked like it worked since the mouse position would cause the window to be teleported, but this was a hack and also caused a flash where the window appeared on the first monitor for a second.

This fixes the above issue and is a better implementation